### PR TITLE
Add package: libzip-dynamic

### DIFF
--- a/.pipelines/build-package-preconfigured.yml
+++ b/.pipelines/build-package-preconfigured.yml
@@ -13,6 +13,7 @@ parameters:
   - ffmpeg
   - libpng
   - libzip-static
+  - libzip-dynamic
   - openssl-static
   - opencv4
   - pango

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -79,6 +79,19 @@
       }
     },
     {
+      "name": "libzip-dynamic",
+      "mac": {
+        "package": "libzip[core]",
+        "linkType": "dynamic",
+        "buildType": "release"
+      },
+      "win": {
+        "package": "libzip[core]",
+        "linkType": "dynamic",
+        "buildType": "release"
+      }
+    },
+    {
       "name": "tinyxml",
       "mac": {
         "package": "tinyxml",

--- a/ps-modules/Build/Build.psm1
+++ b/ps-modules/Build/Build.psm1
@@ -234,7 +234,7 @@ function Run-StageArtifactsStep {
    $dependenciesJson = Get-Content -Raw -Path "$stagedArtifactsPath/$artifactName/$dependenciesFilename" | ConvertFrom-Json
    $packageNameOnly = (Get-PackageNameOnly $packageAndFeatures)
    $packageVersion = ($dependenciesJson.PSObject.Properties.Value | Where-Object { $_.package_name -eq $packageNameOnly } | Select-Object -First 1).version
-   Write-ReleaseInfoJson -packageName $packageNameOnly -version $packageVersion -pathToJsonFile "$stagedArtifactsPath/$artifactName/$packageInfoFilename"
+   Write-ReleaseInfoJson -packageName $packageName -version $packageVersion -pathToJsonFile "$stagedArtifactsPath/$artifactName/$packageInfoFilename"
    
    # TODO: Add info in this file on where each package was downloaded from
    # TODO: Add license file info to the staged artifacts (ex. per-library LICENSE, COPYING, or other such files that commonly have license info in them)


### PR DESCRIPTION
# Description
This adds the libzip-dynamic package to the preconfigured package options.  It also fixes an issue where the release name's base tag name did not match packageName in preconfigured-packages.json, as intended.