### PR TITLE
Add package: hunspell, add debug build support, and publish license data to artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .vs/
-vcpkg
+vcpkg/
+PreStage/
+StagedArtifacts/

--- a/.pipelines/build-package-preconfigured.yml
+++ b/.pipelines/build-package-preconfigured.yml
@@ -12,6 +12,7 @@ parameters:
   values:
   - ffmpeg
   - hunspell
+  - hunspell-debug
   - libpng
   - libzip-static
   - libzip-dynamic

--- a/.pipelines/build-package-preconfigured.yml
+++ b/.pipelines/build-package-preconfigured.yml
@@ -11,6 +11,7 @@ parameters:
   type: string
   values:
   - ffmpeg
+  - hunspell
   - libpng
   - libzip-static
   - libzip-dynamic

--- a/build-and-stage.ps1
+++ b/build-and-stage.ps1
@@ -14,7 +14,7 @@ Run-WriteParamsStep -packageAndFeatures $PackageAndFeatures -scriptArgs $PSBound
 Run-SetupVcPkgStep $VcPkgHash
 Run-PreBuildStep $PackageAndFeatures
 Run-InstallPackageStep -packageAndFeatures $PackageAndFeatures -linkType $LinkType -buildType $BuildType
-Run-FinalizeArtifactsStep -linkType $LinkType -buildType $BuildType
+Run-PrestageAndFinalizeArtifactsStep -linkType $LinkType -buildType $BuildType
 Run-PostBuildStep -packageAndFeatures $PackageAndFeatures -linkType $LinkType -buildType $BuildType
 Run-StageArtifactsStep -packageName $PackageName -packageAndFeatures $PackageAndFeatures -linkType $LinkType -buildType $BuildType -stagedArtifactsPath $StagedArtifactsPath
 

--- a/custom-steps/hunspell/post-build.ps1
+++ b/custom-steps/hunspell/post-build.ps1
@@ -1,0 +1,10 @@
+param (
+    [Parameter(Mandatory=$true)][string]$BuildArtifactsPath
+)
+
+Import-Module "$PSScriptRoot/../../ps-modules/Build" -DisableNameChecking
+
+if (-not (Get-IsOnMacOS)) {
+    exit
+}
+Remove-DylibSymlinks -BuildArtifactsPath $BuildArtifactsPath

--- a/custom-steps/hunspell/post-build.ps1
+++ b/custom-steps/hunspell/post-build.ps1
@@ -4,7 +4,9 @@ param (
 
 Import-Module "$PSScriptRoot/../../ps-modules/Build" -DisableNameChecking
 
-if (-not (Get-IsOnMacOS)) {
-    exit
+if ((Get-IsOnMacOS)) {
+    Remove-DylibSymlinks -BuildArtifactsPath $BuildArtifactsPath
 }
-Remove-DylibSymlinks -BuildArtifactsPath $BuildArtifactsPath
+elseif ((Get-IsOnWindowsOS)) {
+    Update-VersionInfoForDlls -buildArtifactsPath $buildArtifactsPath -versionInfoJsonPath "$PSScriptRoot/version-info.json"
+}

--- a/custom-steps/hunspell/pre-build.ps1
+++ b/custom-steps/hunspell/pre-build.ps1
@@ -1,0 +1,7 @@
+Import-Module "$PSScriptRoot/../../ps-modules/Build" -DisableNameChecking
+
+if (-not (Get-IsOnMacOS)) {
+    exit
+}
+Write-Message "Installing automake..."
+brew install automake

--- a/custom-steps/hunspell/version-info.json
+++ b/custom-steps/hunspell/version-info.json
@@ -1,0 +1,20 @@
+{
+  "files": [
+    {
+      "filename": "bin/hunspell-1.7-0.dll",
+      "fileDescription": "libhunspell",
+      "fileVersion": "1.7.2",
+      "productName": "Hunspell Dynamic Link Library",
+      "productVersion": "1.7.2",
+      "copyright": "Copyright (c) 2007-2022"
+    },
+    {
+      "filename": "bin/charset-1.dll",
+      "fileDescription": "libcharset",
+      "fileVersion": "1.5",
+      "productName": "libcharset 1.5",
+      "productVersion": "1.5",
+      "copyright": ""
+    }
+  ]
+}

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -14,6 +14,19 @@
       }
     },
     {
+      "name": "hunspell",
+      "mac": {
+        "package": "hunspell[core]",
+        "linkType": "dynamic",
+        "buildType": "release"
+      },
+      "win": {
+        "package": "hunspell[core]",
+        "linkType": "dynamic",
+        "buildType": "release"
+      }
+    },
+    {
       "name": "libpng",
       "mac": {
         "package": "libpng",

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -27,6 +27,19 @@
       }
     },
     {
+      "name": "hunspell-debug",
+      "mac": {
+        "package": "hunspell[core]",
+        "linkType": "dynamic",
+        "buildType": "debug"
+      },
+      "win": {
+        "package": "hunspell[core]",
+        "linkType": "dynamic",
+        "buildType": "debug"
+      }
+    },
+    {
       "name": "libpng",
       "mac": {
         "package": "libpng",


### PR DESCRIPTION
# Description
The primary goal of this PR is to add hunspell support for use by Snagit.  It also adds support for creating debug builds with this pipeline, which was previously not working properly.  Additionally, it publishes the "shared" folder for vcpkg builds, now, which often will include license information for the individual libraries that are built as part of the package.

# Testing Done
I did the following testing to verify this works as intended.

## Test build pipeline
1. Go to pipeline: [Build Package (preconfigured)](https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_build?definitionId=789) 
2. Click "Run pipeline"
3. For branch/tag, choose this branch (`package/hunspell`)
4. For "package to install" choose "hunspell"
5. Uncheck the "Publish built package artifacts..." option
6. Click "Run"
7. When the build completes, verify the artifacts are published to the pipeline
8. Repeat 1-7 for all other packages except "pango" _(pango is not currently working in the main branch of this repo on Mac, and we do not currently use the build of pango created by this repo)._