### PR TITLE
Add package: whispercpp

### DIFF
--- a/.pipelines/build-package-preconfigured.yml
+++ b/.pipelines/build-package-preconfigured.yml
@@ -24,6 +24,7 @@ parameters:
   - sqlite3
   - sqlite-modern-cpp
   - tinyxml
+  - whispercpp
 
 - name: publishToGitHubRelease
   displayName: Publish built package artifacts to a tagged release in the GitHub repo (A package name + version tag will be created like "somepackage-1.2.3")

--- a/custom-ports/whispercpp/portfile.cmake
+++ b/custom-ports/whispercpp/portfile.cmake
@@ -1,0 +1,17 @@
+# whispercpp
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ggerganov/whisper.cpp
+    REF e72e4158debb04126a0fabedf0452a5551780ea0
+    SHA512 67939e665542931a75a5ea05a873e5e0a73fc18b443720bcfeb340eb7e39818937c0078976320d9799f0643d8759a64adcb2da371e072f1053232802c1c107af
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/custom-ports/whispercpp/portfile.cmake
+++ b/custom-ports/whispercpp/portfile.cmake
@@ -14,4 +14,13 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
+
+# Store all .libs in the root lib directory.  For Windows SHARED builds, these will be import libraries (not static libs).
+file(GLOB_RECURSE LIB_FILES "${CURRENT_PACKAGES_DIR}/lib/static/*.lib")
+foreach(LIB_FILE ${LIB_FILES})
+    get_filename_component(LIB_NAME ${LIB_FILE} NAME)
+    file(RENAME ${LIB_FILE} "${CURRENT_PACKAGES_DIR}/lib/${LIB_NAME}")
+endforeach()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/static")
+
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/custom-ports/whispercpp/vcpkg.json
+++ b/custom-ports/whispercpp/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "whispercpp",
+  "version": "1.5.4",
+  "port-version": 1,
+  "description": "A high-performance inference of OpenAI's Whisper automatic speech recognition (ASR) model.",
+  "homepage": "https://github.com/ggerganov/whisper.cpp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/custom-steps/whispercpp/post-build.ps1
+++ b/custom-steps/whispercpp/post-build.ps1
@@ -1,0 +1,9 @@
+param (
+    [Parameter(Mandatory=$true)][string]$BuildArtifactsPath
+)
+
+Import-Module "$PSScriptRoot/../../ps-modules/Build" -DisableNameChecking
+
+if ((Get-IsOnWindowsOS)) {
+    Update-VersionInfoForDlls -buildArtifactsPath $buildArtifactsPath -versionInfoJsonPath "$PSScriptRoot/version-info.json"
+}

--- a/custom-steps/whispercpp/version-info.json
+++ b/custom-steps/whispercpp/version-info.json
@@ -1,0 +1,12 @@
+{
+  "files": [
+    {
+      "filename": "bin/whisper.dll",
+      "fileDescription": "Whisper speech recognition",
+      "fileVersion": "1.5.4",
+      "productName": "WhisperCpp",
+      "productVersion": "1.5.4",
+      "copyright": "Copyright (c) 2023 Georgi Gerganov"
+    }
+  ]
+}

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -181,6 +181,19 @@
         "linkType": "dynamic",
         "buildType": "release"
       }
+    },
+    {
+      "name": "whispercpp",
+      "mac": {
+        "package": "whispercpp",
+        "linkType": "dynamic",
+        "buildType": "release"
+      },
+      "win": {
+        "package": "whispercpp",
+        "linkType": "dynamic",
+        "buildType": "release"
+      }
     }
   ]
 }


### PR DESCRIPTION
# Description
Add a custom port for whispercpp and add preconfigured packages for it.

# Testing
- [x] Build & verify it publishes correctly
  - [x] Run [Build Package (preconfigured)](https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_build?definitionId=789) on this branch for the whispercpp package
  - [x] Verify build passes (https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_build/results?buildId=299327&view=results)
  - [x] Verify package published successfully (https://github.com/TechSmith/ThirdParty-Packages-vcpkg/releases/tag/whispercpp-1.5.4)
  - [x] Verify Windows dll has version metadata (1.5.4)
- [x] Pull into CommonCpp and verify it builds successfully (https://github.com/TechSmith/CommonCpp/pull/3850/commits/16e790f9f05e95bb7f8ab5e7abe4f149c1054128, https://dev.azure.com/techsmith/CommonCpp/_build/results?buildId=299385&view=results)