### PR TITLE
delete now unnecessary post build step to inject file version 

### DIFF
--- a/custom-steps/expat/version-info.json
+++ b/custom-steps/expat/version-info.json
@@ -2,10 +2,8 @@
     "files": [
       {
         "filename": "bin/libexpat.dll",
-        "fileDescription": "Expat XML Parser 2.5.0",
-        "fileVersion": "2.5.0",
-        "productName": "Expat 2.5.0",
-        "productVersion": "2.5.0",
+        "fileDescription": "Expat XML Parser",
+        "productName": "Expat",
         "copyright": "Copyright © 1997-2022 Thai Open Source Software Center, Clark Cooper, and the Expat maintainers"
       }
     ]


### PR DESCRIPTION
## Overview

Expat fixed the version issue: https://github.com/libexpat/libexpat/pull/785

No need extra post build step

## Test

triggered a custom build: https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_build/results?buildId=309148&view=artifacts&pathAsName=false&type=publishedArtifacts
which shows 2.6.0 version correctly