### PR TITLE
Update/pango and zlib

### DIFF
--- a/.pipelines/build-package-preconfigured.yml
+++ b/.pipelines/build-package-preconfigured.yml
@@ -17,6 +17,7 @@ parameters:
   - libpng
   - libzip-static
   - libzip-dynamic
+  - minizip
   - openssl-static
   - opencv4
   - pango

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -86,13 +86,13 @@
         "package": "pango",
         "linkType": "dynamic",
         "buildType": "release",
-		"vcpkgHash": "66b4b34d99ab272fcf21f2bd12b616e371c6bb31"
+		    "vcpkgHash": "fba75d09065fcc76a25dcf386b1d00d33f5175af"
       },
       "win": {
         "package": "pango",
         "linkType": "dynamic",
         "buildType": "release",
-		"vcpkgHash": "66b4b34d99ab272fcf21f2bd12b616e371c6bb31"
+		    "vcpkgHash": "fba75d09065fcc76a25dcf386b1d00d33f5175af"
       }
     },
     {

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -202,6 +202,19 @@
         "linkType": "dynamic",
         "buildType": "release"
       }
+    },
+    {
+      "name": "minizip",
+      "mac": {
+        "package": "minizip",
+        "linkType": "dynamic",
+        "buildType": "release"
+      },
+      "win": {
+        "package": "minizip",
+        "linkType": "dynamic",
+        "buildType": "release"
+      }
     }
   ]
 }

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -1,19 +1,6 @@
 {
   "packages": [
     {
-      "name": "expat",
-      "mac": {
-        "package": "expat[core]",
-        "linkType": "dynamic",
-        "buildType": "release"
-      },
-      "win": {
-        "package": "expat[core]",
-        "linkType": "dynamic",
-        "buildType": "release"
-      }
-    },
-    {
       "name": "ffmpeg",
       "mac": {
         "package": "ffmpeg[avcodec,avdevice,avfilter,avformat,avresample,swscale,swresample,mp3lame]",


### PR DESCRIPTION
# Description
- Add package: minizip
- Update pango to new vcpkg hash that allows expat v2.6.0
- Remove separate expat prebuilt (we will just use the version in pango for this, for now)