### PR TITLE
Add appendStringToGitHubRelease option

### DIFF
--- a/.pipelines/build-package-preconfigured.yml
+++ b/.pipelines/build-package-preconfigured.yml
@@ -31,10 +31,16 @@ parameters:
   type: boolean
   default: true
 
+- name: appendStringToGitHubRelease
+  displayName: Append a string to a GitHub release (If "20240401" specified, then "somepackage-1.2.3" would become "somepackage-1.2.3--20240401")
+  type: string
+  default: ' '
+
 stages:
 - template: templates/build.yml
   parameters:
     packageName: ${{ parameters.packageName }}
     publishToPipelineArtifacts: true
     publishToGitHubRelease: ${{ parameters.publishToGitHubRelease }}
+    appendStringToGitHubRelease: ${{parameters.appendStringToGitHubRelease}}
     isPreconfiguredBuild: true

--- a/.pipelines/templates/build.yml
+++ b/.pipelines/templates/build.yml
@@ -29,6 +29,11 @@ parameters:
   type: boolean
   default: false
 
+- name: appendStringToGitHubRelease
+  displayName: Append a string to a GitHub release (If "20240401" specified, then "somepackage-1.2.3" would become "somepackage-1.2.3--20240401")
+  type: string
+  default: 
+
 - name: isPreconfiguredBuild
   displayName: isPreconfiguredBuild
   type: boolean
@@ -151,6 +156,7 @@ stages:
           tar -xzvf $artifactZip -C $artifactsUnzippedDir
           Push-Location $artifactsUnzippedDir
           $gitReleaseTagName = ""
+          $gitReleaseTagSuffix = "${{ parameters.appendStringToGitHubRelease }}".Trim()
           if (Test-Path -Path $packageInfoJsonFile -PathType Leaf) {
               $jsonContent = Get-Content -Path $packageInfoJsonFile -Raw | ConvertFrom-Json
               $version = $jsonContent.version
@@ -158,6 +164,9 @@ stages:
               $gitReleaseTagName = "$packageName-$version"
           }
           Pop-Location
+          if( $gitReleaseTagSuffix -ne "") {
+             $gitReleaseTagName += "--$gitReleaseTagSuffix"
+          }
           Write-Host "##vso[task.setvariable variable=gitReleaseTagName]$gitReleaseTagName"
           Write-Host "##vso[task.setvariable variable=gitReleaseNotes]$gitReleaseNotes"
 


### PR DESCRIPTION
# Description
This allows you to select a string to append to a release name.

<img src="https://github.com/TechSmith/ThirdParty-Packages-vcpkg/assets/62569405/840442d6-d7c8-41ad-9e94-f939232d6af5" width="400"/>

<img src="https://github.com/TechSmith/ThirdParty-Packages-vcpkg/assets/62569405/902a401b-59b5-48e8-b68c-5b4849a0ec37" width="600"/>

# Testing
## Test new functionality
1. Go to [Build Package (preconfigured)](https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_build?definitionId=789&_a=summary)
2. Click "Run pipeline"
3. For "Branch/Tag", select "feature/appendStringToRelease"
4. For "Package", select "tinyxml"
5. For "Append a string to a GitHub release...", enter "20240402-1030"
6. Click "Run"
7. Verity the release gets published as "tinyxml-2.6.2--20240402-1030" (see here: https://github.com/TechSmith/ThirdParty-Packages-vcpkg/releases/tag/tinyxml-2.6.2--20240402-1030)

## Regression test
1. Go to [Build Package (preconfigured)](https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_build?definitionId=789&_a=summary)
2. Click "Run pipeline"
3. For "Branch/Tag", select "feature/appendStringToRelease"
4. For "Package", select "tinyxml"
5. Do not enter anything in "Append a string to a GitHub release..."
6. Click "Run"
7. Verity the release gets published as "tinyxml-2.6.2" (see here: https://github.com/TechSmith/ThirdParty-Packages-vcpkg/releases/tag/tinyxml-2.6.2)