### PR TITLE
Update whispercpp-basic to exclude Mac hardware-specific features

### DIFF
--- a/custom-ports/whispercpp-basic/portfile.cmake
+++ b/custom-ports/whispercpp-basic/portfile.cmake
@@ -13,8 +13,11 @@ if(VCPKG_HOST_IS_OSX)
     vcpkg_cmake_configure(
         SOURCE_PATH ${SOURCE_PATH}
         OPTIONS
-            -DWHISPER_METAL_EMBED_LIBRARY=ON
-            -DWHISPER_METAL_NDEBUG=ON
+            -DWHISPER_NO_AVX=ON
+            -DWHISPER_NO_AVX2=ON
+            -DWHISPER_NO_FMA=ON
+            -DWHISPER_NO_F16C=ON
+            -DWHISPER_METAL=OFF
     )
 else()
     vcpkg_cmake_configure(


### PR DESCRIPTION
# Description
In order to supports Macs prior to 2013, we need to disable certain hardware acceleration features.  AVX2 is not supported by Macs prior to 2013, and METAL is not supported by Macs prior to 2012.  We will just turn all of the hardware acceleration off in this build, for maximum compatibility with older Macs.

More info: https://github.com/TechSmith/CommonCpp/blob/b5e80a4898368f100f4f23fe092c40128fff662d/SpeechToTextLib/README.md#hardware-acceleration-mac