### PR TITLE
Fix pango builds & publish logs on build errors

### DIFF
--- a/.pipelines/templates/build.yml
+++ b/.pipelines/templates/build.yml
@@ -72,22 +72,51 @@ stages:
     - template: steps/full-checkout.yml
 
     - powershell: |
-        ./build-package.ps1 -PackageName "${{ parameters.packageName }}" -StagedArtifactsPath "$(Build.ArtifactStagingDirectory)"
+        ./build-package.ps1 -PackageName "${{ parameters.packageName }}" -StagedArtifactsPath "$(Build.ArtifactStagingDirectory)/package"
       displayName: 'Run: install & stage (preconfigured)'
       condition: and(succeeded(), ${{ parameters.isPreconfiguredBuild }})
 
     - powershell: |
-        ./invoke-build.ps1 -PackageAndFeatures "${{ parameters.package }}" -LinkType "${{ parameters.linkType }}" -BuildType "${{ parameters.buildType }}" -StagedArtifactsPath "$(Build.ArtifactStagingDirectory)"
+        ./invoke-build.ps1 -PackageAndFeatures "${{ parameters.package }}" -LinkType "${{ parameters.linkType }}" -BuildType "${{ parameters.buildType }}" -StagedArtifactsPath "$(Build.ArtifactStagingDirectory)/package"
       displayName: 'Run: install & stage (custom)'
       condition: and(succeeded(), ${{ parameters.isCustomBuild }})
 
     - task: PublishBuildArtifacts@1
       displayName: Publish build artifacts
       inputs:
-        pathToPublish: $(Build.ArtifactStagingDirectory)
+        pathToPublish: $(Build.ArtifactStagingDirectory)/package
         artifactName: $(osName)
       condition: and(succeeded(), ${{ parameters.publishToPipelineArtifacts }})
-  
+
+    - powershell: |
+        $source = "vcpkg/buildtrees/"
+        $destination = "logs/"
+        Write-Host "Copying files: $source ==> $destination"
+        if (Test-Path $destination) {
+            Remove-Item -Recurse -Force $destination
+        }
+        Get-ChildItem -Path $source -Recurse -Filter *.log | ForEach-Object {
+          $destPath = $_.FullName -replace [regex]::Escape($source), $destination
+          New-Item -ItemType Directory -Path (Split-Path $destPath) -Force -ErrorAction SilentlyContinue
+          Copy-Item -Path $_.FullName -Destination $destPath
+        }
+        $source = "logs"
+        $destination = "$(Build.ArtifactStagingDirectory)/logs"
+        Write-Host "Moving files: $source ==> $destination"
+        if (Test-Path $destination) {
+            Remove-Item -Recurse -Force $destination
+        }
+        Move-Item -Path $source -Destination $destination -Force
+      displayName: Stage logs for publish (if failed)
+      condition: failed()
+
+    - task: PublishBuildArtifacts@1
+      displayName: Publish logs (if failed)
+      inputs:
+        pathToPublish: $(Build.ArtifactStagingDirectory)/logs
+        artifactName: $(osName)-logs
+      condition: failed()
+
 - stage: PublishToGitHubRelease
   displayName: 'Publish to GitHub Release'
   dependsOn: Build

--- a/custom-steps/pango/pre-build.ps1
+++ b/custom-steps/pango/pre-build.ps1
@@ -1,7 +1,6 @@
 Import-Module "$PSScriptRoot/../../ps-modules/Build" -DisableNameChecking
 
 if ((Get-IsOnMacOS)) {
-	brew uninstall --ignore-dependencies python
-	brew install python@3.11
-	brew link --overwrite python@3.11
+    Write-Message "Installing setuptools..."
+    python3 -m pip install setuptools
 }


### PR DESCRIPTION
# Description
This PR does 2 things:
1. Publishes log files as build artifact(s) on build failures
2. Fixes the pango build on Mac

## Publishing log files as build artifact(s) on build failures
We cannot always repro issues on local machines that we see on the build server.  In order to more easily troubleshoot build failures, I am now publishing `.log` files from the `vcpkg/buildtrees` subdir as a build artifact for each build server (Mac & Windows).  The console output does not always provide enough info to troubleshoot issues that happen on the build server.

## Fix for pango build on Mac
Pango builds using the preconfigured pipeline started failing failing a few months back, and has prevented us from further updates to pango & friends.  We started getting this error on our build agents:

```
../src/2.14.2-7f52ee670b.clean/meson.build:47:0: ERROR: <PythonExternalProgram 'python' -> ['/usr/local/bin/python3']> is not a valid python or it is missing distutils
```

This was due to the fact that Python 3.12 no longer shipped with distutils (see: https://docs.python.org/3/whatsnew/3.12.html), and distutils was required for some of the pango dependencies, including fontconfig and glib.

We knew this previously when we originally set this up, and were working around this by downgrading python to 3.11, where distutils is deprecated but is still shipped with python.  This worked for awhile on our build agents, and then stopped working at some point, for reasons yet unknown.

There is, however, another workaround for this issue, which is to install setuputils: https://stackoverflow.com/questions/77233855/why-did-i-get-an-error-modulenotfounderror-no-module-named-distutils

This uses this second workaround instead, which DOES work on our Mac build agents.

# Testing
- [x] Ran the pango build before the fix and verified that it published the log files as a build artifact
  - Build: https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_build/results?buildId=369344&view=results
  
https://github.com/user-attachments/assets/de1e02ca-efe5-491e-9332-ec970a0dabe2
  
- [x] Ran pango build after these changes, and verified that it succeeded and published the github release: 
  - Build: https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_build/results?buildId=369346&view=results
  - Published artifacts: https://github.com/TechSmith/ThirdParty-Packages-vcpkg/releases/tag/pango-1.50.14--testsuccess-20240823-002