### PR TITLE
Update liblame version

### DIFF
--- a/custom-steps/ffmpeg/version-info.json
+++ b/custom-steps/ffmpeg/version-info.json
@@ -55,6 +55,10 @@
             "productName": "FFmpeg",
             "productVersion": "6.1.1",
             "copyright": "Copyright (C) 2000-2023 FFmpeg Project"
+        },
+        {
+            "filename": "bin/libmp3lame.dll",
+            "fileVersion": "3.100.2.16"
         }
     ]
 }


### PR DESCRIPTION
# Description
Update the build version to use the FFMPEG port version.

Since libmp3lame did not change version numbers between FFMPEG 6.0.0 and 6.1.1, this failed some upstream client upgrade tests.  Changing this version metadata will ensure that it passes these tests and that this dll actually gets replaced during an upgrade.