### PR TITLE
Feature/linux ffmpeg for cloud

### DIFF
--- a/.pipelines/templates/build.yml
+++ b/.pipelines/templates/build.yml
@@ -74,6 +74,13 @@ stages:
 
     - template: steps/full-checkout.yml
 
+    - task: Bash@3
+      condition: and(succeeded(), eq(variables['osName'], 'linux'))
+      inputs:
+        targetType: 'inline'
+        script: sudo apt-get update && sudo apt-get install -y nasm
+      displayName: 'Install Required Linux Package: nasm'
+
     - pwsh: |
         ./build-package.ps1 -PackageName "${{ parameters.packageName }}" -StagedArtifactsPath "$(Build.ArtifactStagingDirectory)/package"
       displayName: 'Run: install & stage (preconfigured)'

--- a/.pipelines/templates/build.yml
+++ b/.pipelines/templates/build.yml
@@ -64,7 +64,7 @@ stages:
         Linux:
           imageName: ubuntu-latest
           osName: linux
-      maxParallel: 2
+      maxParallel: 3
 
     pool:
       vmImage: $(imageName)

--- a/.pipelines/templates/build.yml
+++ b/.pipelines/templates/build.yml
@@ -91,31 +91,37 @@ stages:
       displayName: 'Run: install & stage (custom)'
       condition: and(succeeded(), ${{ parameters.isCustomBuild }})
 
+    - powershell: |
+        echo "##vso[task.setvariable variable=binExists]$(if (Test-Path "$(Build.ArtifactStagingDirectory)/package/bin") { 'true' } else { 'false' })"
+        echo "##vso[task.setvariable variable=srcExists]$(if (Test-Path "$(Build.ArtifactStagingDirectory)/package/src") { 'true' } else { 'false' })"
+      name: CheckDirectories
+      displayName: 'Verify builds ran'
+
     - task: PublishBuildArtifacts@1
       displayName: Publish build artifacts
       inputs:
         pathToPublish: $(Build.ArtifactStagingDirectory)/package/bin
         artifactName: $(osName)-bin
-      condition: and(succeeded(), ${{ parameters.publishToPipelineArtifacts }})
+      condition: and(succeeded(), ${{ parameters.publishToPipelineArtifacts }}, eq(variables.binExists, 'true'))
 
     - task: PublishBuildArtifacts@1
       displayName: Publish build artifacts
       inputs:
         pathToPublish: $(Build.ArtifactStagingDirectory)/package/src
         artifactName: $(osName)-src
-      condition: and(succeeded(), ${{ parameters.publishToPipelineArtifacts }})
+      condition: and(succeeded(), ${{ parameters.publishToPipelineArtifacts }}, eq(variables.srcExists, 'true'))
 
     - pwsh: |
         ./scripts/copy-logs.ps1 -Source "./vcpkg/buildtrees" -Destination "$(Build.ArtifactStagingDirectory)/logs"
       displayName: Stage logs
-      condition: and(succeededOrFailed(), ${{ parameters.publishToPipelineArtifacts }})
+      condition: and(succeededOrFailed(), ${{ parameters.publishToPipelineArtifacts }}, or(eq(variables.binExists, 'true'), eq(variables.srcExists, 'true')))
 
     - task: PublishBuildArtifacts@1
       displayName: Publish logs
       inputs:
         pathToPublish: $(Build.ArtifactStagingDirectory)/logs
         artifactName: $(osName)-logs
-      condition: and(succeededOrFailed(), ${{ parameters.publishToPipelineArtifacts }})
+      condition: and(succeededOrFailed(), ${{ parameters.publishToPipelineArtifacts }}, or(eq(variables.binExists, 'true'), eq(variables.srcExists, 'true')))
 
 - stage: PublishToGitHubRelease
   displayName: 'Publish to GitHub Release'

--- a/.pipelines/templates/build.yml
+++ b/.pipelines/templates/build.yml
@@ -150,10 +150,12 @@ stages:
         targetType: 'inline'
         workingDirectory: $(Build.SourcesDirectory)/artifacts
         script: |
-          $paths = @( "./mac-bin", "./win-bin", "./mac-src", "./win-src" )
+          $paths = @( "./mac-bin", "./win-bin", "./mac-src", "./win-src", "./linux-bin", "./linux-src" )
           foreach ($path in $paths) {
-              Move-Item -Path "$path/*" -Destination . -Force
-              Remove-Item -Path $path -Recurse -Force
+              if (Test-Path $path) {
+                  Move-Item -Path "$path/*" -Destination . -Force
+                  Remove-Item -Path $path -Recurse -Force
+              }
           }
 
     - task: CopyFiles@2

--- a/.pipelines/templates/build.yml
+++ b/.pipelines/templates/build.yml
@@ -74,13 +74,6 @@ stages:
 
     - template: steps/full-checkout.yml
 
-    - task: Bash@3
-      condition: and(succeeded(), eq(variables['osName'], 'linux'))
-      inputs:
-        targetType: 'inline'
-        script: sudo apt-get update && sudo apt-get install -y nasm
-      displayName: 'Install Required Linux Package: nasm'
-
     - pwsh: |
         ./build-package.ps1 -PackageName "${{ parameters.packageName }}" -StagedArtifactsPath "$(Build.ArtifactStagingDirectory)/package"
       displayName: 'Run: install & stage (preconfigured)'

--- a/.pipelines/templates/build.yml
+++ b/.pipelines/templates/build.yml
@@ -61,6 +61,9 @@ stages:
         Mac:
           imageName: macOS-14
           osName: mac
+        Linux:
+          imageName: ubuntu-latest
+          osName: linux
       maxParallel: 2
 
     pool:

--- a/README.md
+++ b/README.md
@@ -32,3 +32,14 @@ It does the following:
 2. Gets the latest vcpkg from our clone of it (see: [TechSmith/vcpkg](https://github.com/TechSmith/vcpkg))
 3. Builds the package for Mac and Windows
 4. Publishes these packages as pipeline artifacts
+
+### Testing Linux Builds Locally
+Linux builds can be developed and run from Windows via WSL.  The ffmpeg-cloud pre-configured package for example was created using Ubuntu, which is the default WSL OS.
+
+A few system packages are required to run the powershell `build-package.ps1` script, specifically `clang` (or a similar compiler) and `pkg-config`.  Some pre-configured builds require additional packages, such as ffmpeg-cloud needing `nasm`.  You can install them via:
+```
+sudo apt update
+sudo apt install clang, pkg-config, nasm
+```
+
+Given that WSL is quite slow when reading / writing files between Linux and Windows, it's best to run builds directly within a Linux mounted file location (for example `~/projects/ThirdParty-Packages-vcpkg` instead of `/mnt/c/projects/ThirdParty-Packages-vcpkg`).

--- a/README.md
+++ b/README.md
@@ -36,10 +36,4 @@ It does the following:
 ### Testing Linux Builds Locally
 Linux builds can be developed and run from Windows via WSL.  The ffmpeg-cloud pre-configured package for example was created using Ubuntu, which is the default WSL OS.
 
-A few system packages are required to run the powershell `build-package.ps1` script, specifically `clang` (or a similar compiler) and `pkg-config`.  Some pre-configured builds require additional packages, such as ffmpeg-cloud needing `nasm`.  You can install them via:
-```
-sudo apt update
-sudo apt install clang, pkg-config, nasm
-```
-
 Given that WSL is quite slow when reading / writing files between Linux and Windows, it's best to run builds directly within a Linux mounted file location (for example `~/projects/ThirdParty-Packages-vcpkg` instead of `/mnt/c/projects/ThirdParty-Packages-vcpkg`).

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -9,5 +9,11 @@ Import-Module "$PSScriptRoot/scripts/ps-modules/Build" -Force -DisableNameChecki
 Write-Banner -Level 1 -Title "Installing preconfigured package: `"$PackageName`""
 $pkg = Get-PackageInfo -PackageName $PackageName
 
+if ($pkg -eq $null) {
+    $selectedSection = if ((Get-IsOnWindowsOS)) { "win" } elseif ((Get-IsOnMacOS)) { "mac" } else { "linux" }
+    Write-Message "Package $PackageName contains no section for $selectedSection, skipping build."
+    exit 0
+}
+
 Write-Message "$(NL)Running invoke-build.ps1...$(NL)"
 ./invoke-build.ps1 -PackageName $PackageName -PackageAndFeatures $pkg.package -LinkType $pkg.linkType -BuildType $pkg.buildType -StagedArtifactsPath $StagedArtifactsPath -VcpkgHash $pkg.vcpkgHash -Publish $pkg.publish -ShowDebug:$ShowDebug

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -10,7 +10,7 @@ Write-Banner -Level 1 -Title "Installing preconfigured package: `"$PackageName`"
 $pkg = Get-PackageInfo -PackageName $PackageName
 
 if ($pkg -eq $null) {
-    $selectedSection = if ((Get-IsOnWindowsOS)) { "win" } elseif ((Get-IsOnMacOS)) { "mac" } else { "linux" }
+    $selectedSection = Get-OSType
     Write-Message "Package $PackageName contains no section for $selectedSection, skipping build."
     exit 0
 }

--- a/custom-steps/ffmpeg-cloud/post-build.ps1
+++ b/custom-steps/ffmpeg-cloud/post-build.ps1
@@ -17,3 +17,8 @@ if((Get-IsOnWindowsOS)) {
     Remove-Item -Recurse -Force "$buildArtifactsPath/tools"
 }
 
+if((Get-IsOnLinux)) {
+    Get-ChildItem $buildArtifactsPath -Recurse -Include ffmpeg, ffprobe, lame -File | Move-Item -Destination $buildArtifactsPath
+    Remove-Item -Recurse -Force "$buildArtifactsPath/tools"
+}
+

--- a/custom-steps/ffmpeg-cloud/pre-build.ps1
+++ b/custom-steps/ffmpeg-cloud/pre-build.ps1
@@ -1,7 +1,30 @@
 Import-Module "$PSScriptRoot/../../scripts/ps-modules/Build" -DisableNameChecking
 
-if (-not (Get-IsOnMacOS)) {
-    exit
+if (Get-IsOnMacOS) {
+    Write-Message "Installing nasm..."
+    brew install nasm
 }
-Write-Message "Installing nasm..."
-brew install nasm
+
+if (Get-IsOnLinux) {
+    Write-Message "Verifying required packages are installed..."
+
+    $isClangMissing = -not(dpkg-query -W -f='${Status}' clang 2>/dev/null | Select-String "install ok installed");
+    $isPkgConfigMissing = -not(dpkg-query -W -f='${Status}' pkg-config 2>/dev/null | Select-String "install ok installed");
+    $isNasmMissing = -not(dpkg-query -W -f='${Status}' nasm 2>/dev/null | Select-String "install ok installed");
+
+    if ($isClangMissing -or $isPkgConfigMissing -or $isNasmMissing) {
+        sudo apt-get update
+    }
+
+    if ($isClangMissing) {
+        sudo apt-get install -y clang
+    }
+
+    if ($isPkgConfigMissing) {
+        sudo apt-get install -y pkg-config
+    }
+
+    if ($isNasmMissing) {
+        sudo apt-get install -y nasm
+    }
+}

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -17,19 +17,6 @@
     },
     {
       "name": "ffmpeg-cloud",
-      "mac": {
-        "package": "ffmpeg-cloud[core,avcodec,avdevice,avfilter,avformat,avresample,swscale,swresample,mp3lame,ffmpeg,ffprobe,x264,openssl,mjpeg,png,zlib]",
-        "linkType": "static",
-        "buildType": "release",
-        "vcpkgHash": "6db51d86a9c2796581d74c9a7eb46e52ee8cb7eb",
-        "publish": {
-          "include": false,
-          "lib": false,
-          "bin": false,
-          "share": true,
-          "tools": true
-        }
-      },
       "win": {
         "package": "ffmpeg-cloud[core,avcodec,avdevice,avfilter,avformat,avresample,swscale,swresample,mp3lame,ffmpeg,ffprobe,x264,openssl,mjpeg,png,zlib]",
         "linkType": "static",

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -42,6 +42,19 @@
           "share": true,
           "tools": true
         }
+      },
+      "linux": {
+        "package": "ffmpeg-cloud[core,avcodec,avdevice,avfilter,avformat,avresample,swscale,swresample,mp3lame,ffmpeg,ffprobe,x264,openssl,mjpeg,png,zlib]",
+        "linkType": "static",
+        "buildType": "release",
+        "vcpkgHash": "6db51d86a9c2796581d74c9a7eb46e52ee8cb7eb",
+        "publish": {
+          "include": false,
+          "lib": false,
+          "bin": false,
+          "share": true,
+          "tools": true
+        }
       }
     },
     {

--- a/scripts/ps-modules/Build/Build.psm1
+++ b/scripts/ps-modules/Build/Build.psm1
@@ -28,6 +28,8 @@ function Get-Triplets {
    )
    if (Get-IsOnWindowsOS) {
        return @("x64-windows-$linkType-$buildType")
+   } elseif (Get-IsOnLinux) {
+       return @("x64-linux") # using microsoft provided release
    } elseif (Get-IsOnMacOS) {
        return @("x64-osx-$linkType-$buildType", "arm64-osx-$linkType-$buildType")
    }
@@ -41,7 +43,7 @@ function Get-PreStagePath {
 function Get-VcPkgExe {
    if ( (Get-IsOnWindowsOS) ) {
       return "./vcpkg/vcpkg.exe"
-   } elseif ( (Get-IsOnMacOS) ) {
+   } elseif ( (Get-IsOnMacOS) -or (Get-IsOnLinux) ) {
       return "./vcpkg/vcpkg"
    }
    throw [System.Exception]::new("Invalid OS")
@@ -63,6 +65,8 @@ function Get-ArtifactName {
       return "$packageName-windows-$buildType"
    } elseif ( (Get-IsOnMacOS) ) {
       return "$packageName-osx-$buildType"
+   } elseif ( (Get-IsOnLinux) ) {
+      return "$packageName-linux-$buildType"
    }
    throw [System.Exception]::new("Invalid OS")
 }
@@ -166,7 +170,7 @@ function Run-CleanupStep {
    Write-Message "Removing vcpkg cache..."
    if ( (Get-IsOnWindowsOS) ) {
        $vcpkgCacheDir = "$env:LocalAppData/vcpkg/archives"
-   } elseif ( (Get-IsOnMacOS) ) {
+   } elseif ( (Get-IsOnMacOS) -or (Get-IsOnLinux) ) {
       $vcpkgCacheDir = "$HOME/.cache/vcpkg/archives"
    }
    if (Test-Path -Path $vcpkgCacheDir -PathType Container) {
@@ -195,7 +199,7 @@ function Run-SetupVcpkgStep {
    $installDir = "./vcpkg"
    if ( (Get-IsOnWindowsOS) ) {
        $bootstrapScript = "./bootstrap-vcpkg.bat"
-   } elseif ( (Get-IsOnMacOS) ) {
+   } elseif ( (Get-IsOnMacOS) -or (Get-IsOnLinux) ) {
        $bootstrapScript = "./bootstrap-vcpkg.sh"
    }
 
@@ -261,7 +265,7 @@ function Run-PrestageAndFinalizeBuildArtifactsStep {
 
    # Get dirs to copy
    $srcToDestDirs = @{}
-   if ((Get-IsOnWindowsOS)) {  
+   if ((Get-IsOnWindowsOS) -or (Get-IsOnLinux)) {  
       $firstTriplet = (Get-Triplets -linkType $linkType -buildType $buildType) | Select-Object -First 1
       $mainSrcDir = "./vcpkg/installed/$firstTriplet"
       $srcToDestDirs = @{
@@ -309,7 +313,7 @@ function Run-PrestageAndFinalizeBuildArtifactsStep {
        if((Get-IsOnWindowsOS)) {
          Copy-Item -Path $srcDir -Destination $destDir -Force -Recurse
        }
-       elseif((Get-IsOnMacOS)) {
+       elseif((Get-IsOnMacOS) -or (Get-IsOnLinux)) {
           cp -RP "$srcDir" "$destDir"
        }
      }
@@ -431,7 +435,7 @@ function Resolve-Symlink {
 }
 
 Export-ModuleMember -Function Get-PackageInfo, Run-WriteParamsStep, Run-SetupVcpkgStep, Run-PreBuildStep, Run-InstallPackageStep, Run-PrestageAndFinalizeBuildArtifactsStep, Run-PostBuildStep, Run-StageBuildArtifactsStep, Run-StageSourceArtifactsStep, Run-CleanupStep
-Export-ModuleMember -Function NL, Write-Banner, Write-Message, Get-PSObjectAsFormattedList, Get-IsOnMacOS, Get-IsOnWindowsOS, Resolve-Symlink
+Export-ModuleMember -Function NL, Write-Banner, Write-Message, Get-PSObjectAsFormattedList, Get-IsOnMacOS, Get-IsOnWindowsOS, Get-IsOnLinux, Resolve-Symlink
 
 if ( (Get-IsOnMacOS) ) {
    Import-Module "$PSScriptRoot/../../ps-modules/MacBuild" -DisableNameChecking -Force

--- a/scripts/ps-modules/Build/Build.psm1
+++ b/scripts/ps-modules/Build/Build.psm1
@@ -129,7 +129,7 @@ function Get-PackageInfo
         Write-Message "> Package not found in $jsonFilePath."
         exit
     }
-    $selectedSection = if ((Get-IsOnWindowsOS)) { "win" } else { "mac" }
+    $selectedSection = if ((Get-IsOnWindowsOS)) { "win" } elseif ((Get-IsOnMacOS)) { "mac" } else { "linux" }
     $pkgInfo = $pkg.$selectedSection
 
     # Deal with any optional properties that might not be specified in the json file
@@ -139,6 +139,10 @@ function Get-PackageInfo
       "bin" = $true
       "share" = $true
       "tools" = $false
+    }
+
+    if (-not ($pkgInfo.PSObject)) {
+      return $null;
     }
 
     if (-not ($pkgInfo.PSObject.Properties["publish"])) {

--- a/scripts/ps-modules/Build/Build.psm1
+++ b/scripts/ps-modules/Build/Build.psm1
@@ -129,7 +129,7 @@ function Get-PackageInfo
         Write-Message "> Package not found in $jsonFilePath."
         exit
     }
-    $selectedSection = if ((Get-IsOnWindowsOS)) { "win" } elseif ((Get-IsOnMacOS)) { "mac" } else { "linux" }
+    $selectedSection = Get-OSType;
     $pkgInfo = $pkg.$selectedSection
 
     # Deal with any optional properties that might not be specified in the json file
@@ -439,7 +439,7 @@ function Resolve-Symlink {
 }
 
 Export-ModuleMember -Function Get-PackageInfo, Run-WriteParamsStep, Run-SetupVcpkgStep, Run-PreBuildStep, Run-InstallPackageStep, Run-PrestageAndFinalizeBuildArtifactsStep, Run-PostBuildStep, Run-StageBuildArtifactsStep, Run-StageSourceArtifactsStep, Run-CleanupStep
-Export-ModuleMember -Function NL, Write-Banner, Write-Message, Get-PSObjectAsFormattedList, Get-IsOnMacOS, Get-IsOnWindowsOS, Get-IsOnLinux, Resolve-Symlink
+Export-ModuleMember -Function NL, Write-Banner, Write-Message, Get-PSObjectAsFormattedList, Get-IsOnMacOS, Get-IsOnWindowsOS, Get-IsOnLinux, Get-OSType, Resolve-Symlink
 
 if ( (Get-IsOnMacOS) ) {
    Import-Module "$PSScriptRoot/../../ps-modules/MacBuild" -DisableNameChecking -Force

--- a/scripts/ps-modules/Util/Util.psm1
+++ b/scripts/ps-modules/Util/Util.psm1
@@ -50,6 +50,10 @@ function Get-IsOnMacOS {
     return $false
 }
 
+function Get-IsOnLinux {
+    $IsLinux
+}
+
 function Invoke-Powershell {
     param (
         [string]$FilePath,
@@ -144,4 +148,4 @@ function Run-ScriptIfExists {
    Invoke-Powershell -FilePath $script -ArgumentList $scriptArgs
 }
 
-Export-ModuleMember -Function Show-FileContent, Install-FromVcpkg, Exit-IfError, Write-ReleaseInfoJson, Get-IsOnMacOS, Get-IsOnWindowsOS, Invoke-Powershell, Write-Banner, Write-Message, Write-Debug, NL, Get-PSObjectAsFormattedList, Run-ScriptIfExists
+Export-ModuleMember -Function Show-FileContent, Install-FromVcpkg, Exit-IfError, Write-ReleaseInfoJson, Get-IsOnMacOS, Get-IsOnWindowsOS, Get-IsOnLinux, Invoke-Powershell, Write-Banner, Write-Message, Write-Debug, NL, Get-PSObjectAsFormattedList, Run-ScriptIfExists

--- a/scripts/ps-modules/Util/Util.psm1
+++ b/scripts/ps-modules/Util/Util.psm1
@@ -54,6 +54,16 @@ function Get-IsOnLinux {
     $IsLinux
 }
 
+function Get-OSType {
+    if ((Get-IsOnWindowsOS)) {
+        return "win"
+    }
+    if ((Get-IsOnMacOS)) {
+        return "mac"
+    }
+    return "linux"
+}
+
 function Invoke-Powershell {
     param (
         [string]$FilePath,
@@ -148,4 +158,4 @@ function Run-ScriptIfExists {
    Invoke-Powershell -FilePath $script -ArgumentList $scriptArgs
 }
 
-Export-ModuleMember -Function Show-FileContent, Install-FromVcpkg, Exit-IfError, Write-ReleaseInfoJson, Get-IsOnMacOS, Get-IsOnWindowsOS, Get-IsOnLinux, Invoke-Powershell, Write-Banner, Write-Message, Write-Debug, NL, Get-PSObjectAsFormattedList, Run-ScriptIfExists
+Export-ModuleMember -Function Show-FileContent, Install-FromVcpkg, Exit-IfError, Write-ReleaseInfoJson, Get-IsOnMacOS, Get-IsOnWindowsOS, Get-IsOnLinux, Get-OSType, Invoke-Powershell, Write-Banner, Write-Message, Write-Debug, NL, Get-PSObjectAsFormattedList, Run-ScriptIfExists


### PR DESCRIPTION
FFMPEG-Cloud now creates a Linux specific version of ffmpeg.  We also no longer require unneeded environments for pre-configured packages (for example, ffmpeg-cloud drops mac).  The builds still run but gracefully exit when the pre-configured package cannot find a section for the agent's environment.