### PR TITLE
Updated whispercpp and whispercpp-basic ports

### DIFF
--- a/custom-ports/whispercpp-basic/0001-UpdateTargetName.patch
+++ b/custom-ports/whispercpp-basic/0001-UpdateTargetName.patch
@@ -1,16 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 82913aa..a77592a 100644
+index 16a00ad..3824bae 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -683,9 +683,10 @@ include_directories (
-     .
- )
- # Set the version numbers
--set_target_properties(whisper PROPERTIES
-+set_target_properties(${TARGET} PROPERTIES
-     VERSION ${PROJECT_VERSION}
-     SOVERSION ${SOVERSION}
-+    OUTPUT_NAME "whisper-basic"
- )
+@@ -143,7 +143,7 @@ set(WHISPER_BIN_INSTALL_DIR     ${CMAKE_INSTALL_BINDIR}     CACHE PATH "Location
  
- include(DefaultTargetOptions)
+ get_directory_property(WHISPER_TRANSIENT_DEFINES COMPILE_DEFINITIONS)
+ 
+-set_target_properties(whisper PROPERTIES PUBLIC_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/include/whisper.h)
++set_target_properties(whisper PROPERTIES OUTPUT_NAME "whisper-basic" PUBLIC_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/include/whisper.h)
+ install(TARGETS whisper LIBRARY PUBLIC_HEADER)
+ 
+ configure_package_config_file(

--- a/custom-ports/whispercpp-basic/portfile.cmake
+++ b/custom-ports/whispercpp-basic/portfile.cmake
@@ -3,30 +3,31 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ggerganov/whisper.cpp
     REF "v${VERSION}"
-    SHA512 17e0485fb93fdea1a89f584a64db35f05371e0b8710a539f0dffca30bd3a2fff44c72ea754556566ca3cc55415b1e8f2bb868665437f5c93b9ce666b4fe53fb3
+    SHA512 944d8a6e4a770462e77139d918fd1d5b93efca377051d83a584d91164ec73fa50b5bfbc7d85014151b3b5c80fa59cfd386e456960401f8b3c66a9788585cac46
     HEAD_REF master
     PATCHES
         0001-UpdateTargetName.patch
 )
 
+set(VCPKG_POLICY_SKIP_MISPLACED_CMAKE_FILES_CHECK enabled)
+set(VCPKG_POLICY_SKIP_LIB_CMAKE_MERGE_CHECK enabled)
 if(VCPKG_HOST_IS_OSX)
     vcpkg_cmake_configure(
         SOURCE_PATH ${SOURCE_PATH}
         OPTIONS
-            -DWHISPER_NO_AVX=ON
-            -DWHISPER_NO_AVX2=ON
-            -DWHISPER_NO_FMA=ON
-            -DWHISPER_NO_F16C=ON
-            -DWHISPER_METAL=OFF
+            -DGGML_AVX=OFF
+            -DGGML_AVX2=OFF
+            -DGGML_FMA=OFF
+            -DGGML_F16C=OFF
+            -DGGML_METAL=OFF
     )
 else()
     vcpkg_cmake_configure(
         SOURCE_PATH ${SOURCE_PATH}
         OPTIONS
-            -DWHISPER_NO_AVX=ON
-            -DWHISPER_NO_AVX2=ON
-            -DWHISPER_NO_FMA=ON
-            -DWHISPER_NO_F16C=ON
+            -DGGML_AVX=OFF
+            -DGGML_AVX2=OFF
+            -DGGML_FMA=OFF
     )
 endif()
 
@@ -42,3 +43,5 @@ endforeach()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/static")
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+
+vcpkg_fixup_pkgconfig()

--- a/custom-ports/whispercpp-basic/vcpkg.json
+++ b/custom-ports/whispercpp-basic/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "whispercpp-basic",
-  "version": "1.6.2",
+  "version": "1.7.1",
   "port-version": 1,
   "description": "High-performance inference of OpenAI's Whisper automatic speech recognition (ASR) model.  This dll is built without enhanced CPU support for AVX, AVX2, FMA or F16C.",
   "homepage": "https://github.com/ggerganov/whisper.cpp",

--- a/custom-ports/whispercpp/portfile.cmake
+++ b/custom-ports/whispercpp/portfile.cmake
@@ -3,16 +3,18 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ggerganov/whisper.cpp
     REF "v${VERSION}"
-    SHA512 17e0485fb93fdea1a89f584a64db35f05371e0b8710a539f0dffca30bd3a2fff44c72ea754556566ca3cc55415b1e8f2bb868665437f5c93b9ce666b4fe53fb3
+    SHA512 944d8a6e4a770462e77139d918fd1d5b93efca377051d83a584d91164ec73fa50b5bfbc7d85014151b3b5c80fa59cfd386e456960401f8b3c66a9788585cac46
     HEAD_REF master
 )
 
+set(VCPKG_POLICY_SKIP_MISPLACED_CMAKE_FILES_CHECK enabled)
+set(VCPKG_POLICY_SKIP_LIB_CMAKE_MERGE_CHECK enabled)
 if(VCPKG_HOST_IS_OSX)
     vcpkg_cmake_configure(
         SOURCE_PATH ${SOURCE_PATH}
         OPTIONS
-            -DWHISPER_METAL_EMBED_LIBRARY=ON
-            -DWHISPER_METAL_NDEBUG=ON
+            -DGGML_METAL_EMBED_LIBRARY=ON
+            -DGGML_METAL_NDEBUG=ON
     )
 else()
     vcpkg_cmake_configure(
@@ -32,3 +34,5 @@ endforeach()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/static")
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+
+vcpkg_fixup_pkgconfig()

--- a/custom-ports/whispercpp/vcpkg.json
+++ b/custom-ports/whispercpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "whispercpp",
-  "version": "1.6.2",
+  "version": "1.7.1",
   "port-version": 1,
   "description": "A high-performance inference of OpenAI's Whisper automatic speech recognition (ASR) model.",
   "homepage": "https://github.com/ggerganov/whisper.cpp",

--- a/custom-steps/whispercpp-basic/version-info.json
+++ b/custom-steps/whispercpp-basic/version-info.json
@@ -3,9 +3,9 @@
     {
       "filename": "bin/whisper-basic.dll",
       "fileDescription": "High-performance inference of OpenAI's Whisper automatic speech recognition (ASR) model.  This dll is built without enhanced CPU support for AVX, AVX2, FMA or F16C.",
-      "fileVersion": "1.6.2",
+      "fileVersion": "1.7.1",
       "productName": "WhisperCpp",
-      "productVersion": "1.6.2",
+      "productVersion": "1.7.1",
       "copyright": "Copyright (c) 2023-2024 The ggml authors"
     }
   ]

--- a/custom-steps/whispercpp/version-info.json
+++ b/custom-steps/whispercpp/version-info.json
@@ -3,9 +3,9 @@
     {
       "filename": "bin/whisper.dll",
       "fileDescription": "High-performance inference of OpenAI's Whisper automatic speech recognition (ASR) model.",
-      "fileVersion": "1.6.2",
+      "fileVersion": "1.7.1",
       "productName": "WhisperCpp",
-      "productVersion": "1.6.2",
+      "productVersion": "1.7.1",
       "copyright": "Copyright (c) 2023-2024 The ggml authors"
     }
   ]


### PR DESCRIPTION
1. Updated version from 1.6.2 to 1.7.1
2. Updated patch to work with new version of CMakeLists.txt
3. Updated WHISPER_ flags to GGML_ equivalent flags in portfile.cmake
4. Added vcpkg_fixup_pkgconfig() to fix full paths to files in .pc file