### PR TITLE
Cloud FFMPEG built as non-redistributable, many additional decoders

### DIFF
--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -18,7 +18,7 @@
     {
       "name": "ffmpeg-cloud",
       "win": {
-        "package": "ffmpeg-cloud[core,avcodec,avdevice,avfilter,avformat,avresample,swscale,swresample,mp3lame,ffmpeg,ffprobe,x264,openssl,mjpeg,png,zlib]",
+        "package": "ffmpeg-cloud[core,avcodec,avdevice,avfilter,avformat,avresample,swscale,swresample,mp3lame,ffmpeg,ffprobe,openssl,mjpeg,png,zlib,nvcodec,x264,dav1d,vpx,nonfree,gpl,version3]",
         "linkType": "static",
         "buildType": "release",
         "vcpkgHash": "6db51d86a9c2796581d74c9a7eb46e52ee8cb7eb",
@@ -31,7 +31,7 @@
         }
       },
       "linux": {
-        "package": "ffmpeg-cloud[core,avcodec,avdevice,avfilter,avformat,avresample,swscale,swresample,mp3lame,ffmpeg,ffprobe,x264,openssl,mjpeg,png,zlib]",
+        "package": "ffmpeg-cloud[core,avcodec,avdevice,avfilter,avformat,avresample,swscale,swresample,mp3lame,ffmpeg,ffprobe,openssl,mjpeg,png,zlib,nvcodec,x264,dav1d,vpx,nonfree,gpl,version3]",
         "linkType": "static",
         "buildType": "release",
         "vcpkgHash": "6db51d86a9c2796581d74c9a7eb46e52ee8cb7eb",


### PR DESCRIPTION
Additional decoders and libraries enabled for ffmpeg-cloud.  This build cannot be redistributed due to the license requirements, however it can be used by internal workers to process media.