### PR TITLE
+glslang and the ability to specify a customTriplet so we can use x64-windows-static-md

### DIFF
--- a/.pipelines/build-package-preconfigured.yml
+++ b/.pipelines/build-package-preconfigured.yml
@@ -12,6 +12,7 @@ parameters:
   values:
   - ffmpeg
   - ffmpeg-cloud
+  - glslang
   - hunspell
   - hunspell-debug
   - libpng

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -16,4 +16,4 @@ if ($pkg -eq $null) {
 }
 
 Write-Message "$(NL)Running invoke-build.ps1...$(NL)"
-./invoke-build.ps1 -PackageName $PackageName -PackageAndFeatures $pkg.package -LinkType $pkg.linkType -BuildType $pkg.buildType -StagedArtifactsPath $StagedArtifactsPath -VcpkgHash $pkg.vcpkgHash -Publish $pkg.publish -ShowDebug:$ShowDebug
+./invoke-build.ps1 -PackageName $PackageName -PackageAndFeatures $pkg.package -CustomTriplet $pkg.customTriplet -LinkType $pkg.linkType -BuildType $pkg.buildType -StagedArtifactsPath $StagedArtifactsPath -VcpkgHash $pkg.vcpkgHash -Publish $pkg.publish -ShowDebug:$ShowDebug

--- a/invoke-build.ps1
+++ b/invoke-build.ps1
@@ -1,8 +1,9 @@
 param(
     [Parameter(Mandatory=$true)][string]$PackageAndFeatures, # Name of package + optional feature flags ("foo" or "foo[feature1,feature2]")
-    [Parameter(Mandatory=$true)][string]$LinkType,           # Linking type: static or dynamic
+    [string]$LinkType,                                       # Linking type: static or dynamic
     [string]$PackageName = "",                               # The base name of the tag to be used when publishing the release (ex. "openssl-static").  If not specified, it will default to "$Package-$LinkType"
     [string]$BuildType = "release",                          # Build type: release or debug
+    [string]$CustomTriplet = "",                             # Optional: Custom triplet to use for vcpkg. Overrides LinkType and BuildType
     [string]$StagedArtifactsPath = "StagedArtifacts",        # Output path to stage these artifacts to
     [string]$VcpkgHash = "",                                 # The hash of vcpkg to checkout (if applicable)
     [PSObject]$PublishInfo = $false,                         # Optional info on what to publish or not publish to the final artifact
@@ -15,10 +16,10 @@ Run-WriteParamsStep -packageAndFeatures $PackageAndFeatures -scriptArgs $PSBound
 Run-CleanupStep
 Run-SetupVcPkgStep $VcPkgHash
 Run-PreBuildStep $PackageAndFeatures
-Run-InstallPackageStep -packageAndFeatures $PackageAndFeatures -linkType $LinkType -buildType $BuildType
-Run-PrestageAndFinalizeBuildArtifactsStep -linkType $LinkType -buildType $BuildType -publishInfo $PublishInfo
+Run-InstallPackageStep -packageAndFeatures $PackageAndFeatures -linkType $LinkType -buildType $BuildType -customTriplet $CustomTriplet
+Run-PrestageAndFinalizeBuildArtifactsStep -linkType $LinkType -buildType $BuildType -customTriplet $CustomTriplet -publishInfo $PublishInfo
 Run-PostBuildStep -packageAndFeatures $PackageAndFeatures -linkType $LinkType -buildType $BuildType
-Run-StageBuildArtifactsStep -packageName $PackageName -packageAndFeatures $PackageAndFeatures -linkType $LinkType -buildType $BuildType -stagedArtifactsPath $StagedArtifactsPath -publishInfo $PublishInfo
-Run-StageSourceArtifactsStep -packageName $PackageName -packageAndFeatures $PackageAndFeatures -linkType $LinkType -buildType $BuildType -stagedArtifactsPath $StagedArtifactsPath
+Run-StageBuildArtifactsStep -packageName $PackageName -packageAndFeatures $PackageAndFeatures -linkType $LinkType -buildType $BuildType -customTriplet $CustomTriplet -stagedArtifactsPath $StagedArtifactsPath -publishInfo $PublishInfo
+Run-StageSourceArtifactsStep -packageName $PackageName -packageAndFeatures $PackageAndFeatures -linkType $LinkType -buildType $BuildType -customTriplet $CustomTriplet -stagedArtifactsPath $StagedArtifactsPath
 
 Write-Message "$(NL)$(NL)Done.$(NL)"

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -254,8 +254,7 @@
       },
       "win": {
         "package": "glslang",
-        "linkType": "static",
-        "buildType": "release"
+        "customTriplet": "x64-windows-static-md"
       }
     }
   ]

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -254,7 +254,10 @@
       },
       "win": {
         "package": "glslang",
-        "customTriplet": "x64-windows-static-md"
+        "customTriplet": "x64-windows-static-md",
+        "publish": {
+          "debug": true
+        }
       }
     }
   ]

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -62,12 +62,18 @@
       "mac": {
         "package": "hunspell[core]",
         "linkType": "dynamic",
-        "buildType": "debug"
+        "buildType": "debug",
+        "publish": {
+          "debug": true
+        }
       },
       "win": {
         "package": "hunspell[core]",
         "linkType": "dynamic",
-        "buildType": "debug"
+        "buildType": "debug",
+        "publish": {
+          "debug": true
+        }
       }
     },
     {

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -244,6 +244,19 @@
         "linkType": "dynamic",
         "buildType": "release"
       }
+    },
+    {
+      "name": "glslang",
+      "mac": {
+        "package": "glslang",
+        "linkType": "static",
+        "buildType": "release"
+      },
+      "win": {
+        "package": "glslang",
+        "linkType": "static",
+        "buildType": "release"
+      }
     }
   ]
 }

--- a/scripts/ps-modules/Build/Build.psm1
+++ b/scripts/ps-modules/Build/Build.psm1
@@ -28,7 +28,7 @@ function Get-Triplets {
       [string]$customTriplet
    )
 
-   if ($null -ne $customTriplet ) {
+   if ($null -ne $customTriplet -and $customTriplet -ne "") {
        return @($customTriplet)
    }
 

--- a/scripts/ps-modules/Build/Build.psm1
+++ b/scripts/ps-modules/Build/Build.psm1
@@ -395,9 +395,9 @@ function Run-StageBuildArtifactsStep {
 
    # Figure out which folders we should avoid copying from the PublishInfo object
    $excludedFolders = @()
-   if ($null -ne $pkg.publish) {
-      foreach ($member in $pkg.publish | Get-Member -MemberType NoteProperty) {
-          $value = $pkg.publish."$($member.Name)"
+   if ($null -ne $publishInfo) {
+      foreach ($member in $publishInfo | Get-Member -MemberType NoteProperty) {
+          $value = $publishInfo."$($member.Name)"
           if($value -eq $false) {
               $excludedFolders += $member.Name
           }

--- a/scripts/ps-modules/Build/Build.psm1
+++ b/scripts/ps-modules/Build/Build.psm1
@@ -395,11 +395,13 @@ function Run-StageBuildArtifactsStep {
 
    # Figure out which folders we should avoid copying from the PublishInfo object
    $excludedFolders = @()
-   foreach ($member in $pkg.publish | Get-Member -MemberType NoteProperty) {
-       $value = $pkg.publish."$($member.Name)"
-       if($value -eq $false) {
-           $excludedFolders += $member.Name
-       }
+   if ($null -ne $pkg.publish) {
+      foreach ($member in $pkg.publish | Get-Member -MemberType NoteProperty) {
+          $value = $pkg.publish."$($member.Name)"
+          if($value -eq $false) {
+              $excludedFolders += $member.Name
+          }
+      }
    }
 
    Get-ChildItem -Path "$preStagePath" -Exclude $excludedFolders | ForEach-Object { Move-Item -Path "$($_.FullName)" -Destination "$stagedArtifactSubDir/$artifactName" }

--- a/scripts/ps-modules/Build/Build.psm1
+++ b/scripts/ps-modules/Build/Build.psm1
@@ -279,10 +279,6 @@ function Run-PrestageAndFinalizeBuildArtifactsStep {
    $libDir = "lib"
    $binDir = "bin"
    $toolsDir = "tools"
-   if( $buildType -eq "debug" ) {
-      $libDir = "debug/lib"
-      $binDir = "debug/bin"
-   }
 
    # Get dirs to copy
    $srcToDestDirs = @{}

--- a/scripts/ps-modules/Build/Build.psm1
+++ b/scripts/ps-modules/Build/Build.psm1
@@ -28,7 +28,7 @@ function Get-Triplets {
       [string]$customTriplet
    )
 
-   if ($null -ne $customTriplet -and $customTriplet -ne "") {
+   if ( -not [string]::IsNullOrEmpty($customTriplet) ) {
        return @($customTriplet)
    }
 


### PR DESCRIPTION
I needed to build glslang as a static library through vcpkg. Unfortunately, the default C Runtime Library (CRT) setting is set to static, but in order for our code to link it, we need to build the glslang static libraries such that they link *dynamically* to the CRT (using /MD and /MDd flags).

We need to do this for both Debug and Release static libraries, which adds a little more complexity to the deployment process. The way vcpkg does this is it has a directory structure like this:
```
x64-windows-static-md/
  debug/
    lib/<debug binaries linked with /MDd>
  include/<header files here>
  lib/<release binaries linked with /MD>
```

This PR makes very target changes to make this possible. `customTriplet` is passed down through various functions now in order to:
1. Calculate the correct triplet
2. Construct the artifact name
3. Whether to include the contents of the "debug/" folder or not