### PR TITLE
Update variable group to TSCAzureDevOps

### DIFF
--- a/.pipelines/templates/build.yml
+++ b/.pipelines/templates/build.yml
@@ -120,7 +120,9 @@ stages:
   displayName: 'Publish to GitHub Release'
   dependsOn: Build
   condition: and(succeeded(), ${{ parameters.publishToGitHubRelease }})
-
+  variables:
+  - template: steps/build-vars.yml
+  
   jobs:
   - job: PublishToGitHubRelease
     pool:

--- a/.pipelines/templates/steps/build-vars.yml
+++ b/.pipelines/templates/steps/build-vars.yml
@@ -1,3 +1,2 @@
 variables:
-- group: PipelineVars
-#- group: TSCAzureDevOps
+- group: TSCAzureDevOps


### PR DESCRIPTION
# Description
This changes the github username and token used in the AzDO pipelines related to this repo to use ones provided by the build team.

# Testing
- [x] Delete the "Pipeline vars" variable group in AzDO (see: [Library](https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_library?itemType=VariableGroups))
- [x] Run "[Build Package (preconfigured)](https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_build?definitionId=789)" pipeline for tinyxml, entering "2024-11-05-003" for "Append a string to a GitHub release"
- [x] Verify that in the "[Set up git authentication](https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_build/results?buildId=399097&view=logs&j=0fb60f56-4e18-5a88-24d5-7a3466985593&t=49a40966-1764-5e52-438a-0fd5976a6928)" step, there are no longer any errors
- [x] Verify the pipeline ran successfully
- [x] Verify the release got published to the repo [tinyxml-2.6.2--2024-11-05-003](https://github.com/TechSmith/ThirdParty-Packages-vcpkg/releases/tag/tinyxml-2.6.2--2024-11-05-003)