### PR TITLE
Always publish logs if dir exists, even if src or bin dirs do not.

### DIFF
--- a/.pipelines/templates/build.yml
+++ b/.pipelines/templates/build.yml
@@ -106,15 +106,16 @@ stages:
 
     - pwsh: |
         ./scripts/copy-logs.ps1 -Source "./vcpkg/buildtrees" -Destination "$(Build.ArtifactStagingDirectory)/logs"
+        echo "##vso[task.setvariable variable=logsExists]$(if (Test-Path "$(Build.ArtifactStagingDirectory)/logs") { 'true' } else { 'false' })"
       displayName: Stage logs
-      condition: and(succeededOrFailed(), ${{ parameters.publishToPipelineArtifacts }}, or(eq(variables.binExists, 'true'), eq(variables.srcExists, 'true')))
+      condition: and(succeededOrFailed(), ${{ parameters.publishToPipelineArtifacts }})
 
     - task: PublishBuildArtifacts@1
       displayName: Publish logs
       inputs:
         pathToPublish: $(Build.ArtifactStagingDirectory)/logs
         artifactName: $(osName)-logs
-      condition: and(succeededOrFailed(), ${{ parameters.publishToPipelineArtifacts }}, or(eq(variables.binExists, 'true'), eq(variables.srcExists, 'true')))
+      condition: and(succeededOrFailed(), ${{ parameters.publishToPipelineArtifacts }}, eq(variables.logsExists, 'true'))
 
 - stage: PublishToGitHubRelease
   displayName: 'Publish to GitHub Release'

--- a/scripts/copy-logs.ps1
+++ b/scripts/copy-logs.ps1
@@ -4,7 +4,12 @@ param(
 )
 
 Write-Host "Copying logs: $Source ==> $Destination"
+if (-not (Test-Path $Source)) {
+  Write-Host "Source path does not exist: $Source.  Exiting."
+  Exit 0
+}
 if (Test-Path $Destination) {
+    Write-Host "Removing: $Destination..."
     Remove-Item -Recurse -Force $Destination
 }
 Get-ChildItem -Path $Source -Recurse -Filter *.log | ForEach-Object {


### PR DESCRIPTION
# Description
Currently, we only publish the vcpkg logs as build artifacts if the src or bin dirs exist.  Failures can occur before src or bin folders are created, however.  All we really care about, though, is if the logs dir exists.  If there are logs, we should publish them as build artifacts. 

# Testing
## Don't publish logs for environment vcpkg was not run on
- [x] Ran this build for tinyxml: https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_build/results?buildId=402209&view=results
- [x] Verified it did NOT publish logs for Linux and that the "Build Linux" job completed successfully.

## Verify logs get published when vcpkg runs but no bin or src dirs exist
- [x] Ran this build on the `dawn-mwm-tmp` branch: https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_build/results?buildId=402165&view=results
- [x] No logs were published
- [x] Picked these commits over that `dawn-mwm-tmp` branch.
- [x] Ran this build on that branch: https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_build/results?buildId=402210&view=results
- [x] Verified it published logs successfully for Mac and Windows