### PR TITLE
Fix name inside of a src folder being cut off

### DIFF
--- a/scripts/ps-modules/Build/Build.psm1
+++ b/scripts/ps-modules/Build/Build.psm1
@@ -443,7 +443,7 @@ function Run-StageSourceArtifactsStep {
            if (-not (Test-Path -Path $destDir)) {
                New-Item -ItemType Directory -Path $destDir | Out-Null
            }
-           Copy-ItemWithSymlinks -source "$srcDir\*" -destination "$destDir"
+           Copy-ItemWithSymlinks -source "$srcDir" -destination "$destDir"
        }
    }
 


### PR DESCRIPTION
Example: The folder n6.1.1-96429b945d.clean was turning into .1.1-96429b945d.clean, which would show up as a hidden file on unix-based systems