### PR TITLE
Drop unused nvidia option

### DIFF
--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -18,7 +18,7 @@
     {
       "name": "ffmpeg-cloud-gpl",
       "win": {
-        "package": "ffmpeg-cloud-gpl[core,avcodec,avdevice,avfilter,avformat,avresample,swscale,swresample,mp3lame,ffmpeg,ffprobe,openssl,mjpeg,png,zlib,nvcodec,x264,dav1d,vpx,nonfree,gpl,version3]",
+        "package": "ffmpeg-cloud-gpl[core,avcodec,avdevice,avfilter,avformat,avresample,swscale,swresample,mp3lame,ffmpeg,ffprobe,openssl,mjpeg,png,zlib,x264,dav1d,vpx,nonfree,gpl,version3]",
         "linkType": "static",
         "buildType": "release",
         "vcpkgHash": "6db51d86a9c2796581d74c9a7eb46e52ee8cb7eb",
@@ -31,7 +31,7 @@
         }
       },
       "linux": {
-        "package": "ffmpeg-cloud-gpl[core,avcodec,avdevice,avfilter,avformat,avresample,swscale,swresample,mp3lame,ffmpeg,ffprobe,openssl,mjpeg,png,zlib,nvcodec,x264,dav1d,vpx,nonfree,gpl,version3]",
+        "package": "ffmpeg-cloud-gpl[core,avcodec,avdevice,avfilter,avformat,avresample,swscale,swresample,mp3lame,ffmpeg,ffprobe,openssl,mjpeg,png,zlib,x264,dav1d,vpx,nonfree,gpl,version3]",
         "linkType": "static",
         "buildType": "release",
         "vcpkgHash": "6db51d86a9c2796581d74c9a7eb46e52ee8cb7eb",


### PR DESCRIPTION
Dropping nvidia codec from ffmpeg-cloud-gpl as we don't use it.