### PR TITLE
Create hevc and non-hevc decoding builds of ffmpeg

### DIFF
--- a/.pipelines/build-package-preconfigured.yml
+++ b/.pipelines/build-package-preconfigured.yml
@@ -11,9 +11,10 @@ parameters:
   type: string
   values:
   - dawn
-  - ffmpeg
   - ffmpeg-cloud-gpl
-  - ffmpeg-hevc
+  - ffmpeg-desktop-base
+  - ffmpeg-desktop-hevc
+  - ffmpeg-wasm-base
   - glslang
   - hunspell
   - hunspell-debug

--- a/.pipelines/build-package-preconfigured.yml
+++ b/.pipelines/build-package-preconfigured.yml
@@ -13,6 +13,7 @@ parameters:
   - dawn
   - ffmpeg
   - ffmpeg-cloud-gpl
+  - ffmpeg-hevc
   - glslang
   - hunspell
   - hunspell-debug

--- a/custom-ports/ffmpeg/portfile.cmake
+++ b/custom-ports/ffmpeg/portfile.cmake
@@ -43,7 +43,7 @@ string(REPLACE " " ";" OPTIONS ${OPTIONS}) # Convert space-separate list into a 
 list(PREPEND OPTIONS --disable-everything) # Start with "everything" disabled, and build up from there (it disables these things: https://stackoverflow.com/questions/24849129/compile-ffmpeg-without-most-codecs)
 list(APPEND OPTIONS --disable-securetransport) # To avoid AppStore rejection by disabling the use of private API SecIdentityCreate()
 list(APPEND OPTIONS --enable-protocol=file) # Only enable file protocol
-list(APPEND OPTIONS --enable-filter=aresample) # This is needed for converting between formats.  Fixes: "'aresample' filter not present, cannot convert formats."
+list(APPEND OPTIONS --enable-filter=aresample --enable-filter=scale) # These are needed for converting between formats.  Fixes: "'aresample' filter not present, cannot convert formats."
 
 # === Add extra options for emscripten builds ===
 if(VCPKG_TARGET_IS_EMSCRIPTEN)

--- a/custom-ports/ffmpeg/portfile.cmake
+++ b/custom-ports/ffmpeg/portfile.cmake
@@ -131,7 +131,6 @@ set(TSC_DECODERS "")
 set(FEATURE_DECODER_MAP 
    "aom=libaom_av1"
    "dav1d=libdav1d"
-   "mp3lame=libmp3lame"
    "opus=libopus"
    "vorbis=libvorbis"
    "vpx=libvpx_vp8,libvpx_vp9"

--- a/custom-ports/ffmpeg/portfile.cmake
+++ b/custom-ports/ffmpeg/portfile.cmake
@@ -119,6 +119,7 @@ set(FEATURE_ENCODER_MAP
    "encoder-aac-at=aac_at"
    "encoder-aac-mf=aac_mf"
    "encoder-mp3-mf=mp3_mf"
+   "png=png"
 )
 map_features_to_items("${FEATURE_ENCODER_MAP}" "${FEATURES}" TSC_ENCODERS)
 foreach(ENCODER IN LISTS TSC_ENCODERS)
@@ -136,13 +137,14 @@ set(FEATURE_DECODER_MAP
    "vpx=libvpx_vp8,libvpx_vp9"
 
    # Custom feature flags for decoders
-   "decoder-hevc=hevc"
    "decoder-aac=aac,aac_fixed,aac_latm"
    "decoder-aac-at=aac_at"
+   "decoder-hevc=hevc"
    "decoder-mp3=mp3*"
    "decoder-pcm=pcm*"
    "decoder-vp8=vp8" # On2 VP8 decoding (different from libvpx)
    "decoder-vp9=vp9" # Google VP9 decoding (different from libvpx)
+   "png=png"
 )
 map_features_to_items("${FEATURE_DECODER_MAP}" "${FEATURES}" TSC_DECODERS)
 foreach(DECODER IN LISTS TSC_DECODERS)
@@ -160,6 +162,7 @@ set(FEATURE_MUXER_MAP
    "muxer-mpegts=mpegts"
    "muxer-rtp-mpegts=rtp_mpegts"
    "muxer-webm=webm*"
+   "image2=image2"
 )
 map_features_to_items("${FEATURE_MUXER_MAP}" "${FEATURES}" TSC_MUXERS)
 foreach(MUXER IN LISTS TSC_MUXERS)
@@ -176,6 +179,7 @@ set(FEATURE_DEMUXER_MAP
    "demuxer-mp3=mp3"
    "demuxer-mpegts=mpegts,mpegtsraw"
    "demuxer-webm=webm*"
+   "image2=image2"
 )
 map_features_to_items("${FEATURE_DEMUXER_MAP}" "${FEATURES}" TSC_DEMUXERS)
 foreach(DEMUXER IN LISTS TSC_DEMUXERS)

--- a/custom-ports/ffmpeg/vcpkg.json
+++ b/custom-ports/ffmpeg/vcpkg.json
@@ -742,6 +742,8 @@
             "aom",
             "dav1d",
             "ffmpeg",
+            "ffplay",
+            "ffprobe",
             "image2",
             "mp3lame",
             "opus",

--- a/custom-ports/ffmpeg/vcpkg.json
+++ b/custom-ports/ffmpeg/vcpkg.json
@@ -712,6 +712,210 @@
       "dependencies": [
         "zlib"
       ]
+    },
+    "tsc-base": {
+      "description": "The base set of features for all TSC FFmpeg builds",
+      "dependencies": [
+        {
+          "name": "ffmpeg",
+          "default-features": false,
+          "features": [
+            "avcodec",
+            "avdevice",
+            "avfilter",
+            "avformat",
+            "avresample",
+            "swscale",
+            "swresample"
+          ]
+        }
+      ]
+    },
+    "tsc-desktop-base": {
+      "description": "The base set of features for all TSC desktop FFmpeg builds",
+      "dependencies": [
+        {
+          "name": "ffmpeg",
+          "default-features": false,
+          "features": [
+            "tsc-base",
+            "aom",
+            "dav1d",
+            "ffmpeg",
+            "image2",
+            "mp3lame",
+            "opus",
+            "png",
+            "vorbis",
+            "vpx",
+            "zlib",
+            "encoder-aac",
+            "decoder-aac",
+            "decoder-mp3",
+            "decoder-pcm",
+            "decoder-vp8",
+            "decoder-vp9",
+            "muxer-matroska",
+            "muxer-mov",
+            "muxer-mp3",
+            "muxer-mp4",
+            "muxer-mpegts",
+            "muxer-mkvtimestamp-v2",
+            "muxer-rtp-mpegts",
+            "muxer-webm",
+            "muxer-matroska",
+            "demuxer-aac",
+            "demuxer-mov",
+            "demuxer-mp3",
+            "demuxer-mpegts",
+            "demuxer-webm"
+          ]
+        }
+      ]
+    },
+    "tsc-desktop-win": {
+      "description": "The base set of features for all TSC desktop builds for windows",
+      "dependencies": [
+        {
+          "name": "ffmpeg",
+          "default-features": false,
+          "features": [
+            "tsc-desktop-base",
+            "encoder-aac-mf",
+            "encoder-mp3-mf"
+          ]
+        }
+      ]
+    },
+    "tsc-desktop-mac": {
+      "description": "The base set of features for all TSC desktop builds for mac",
+      "dependencies": [
+        {
+          "name": "ffmpeg",
+          "default-features": false,
+          "features": [
+            "tsc-desktop-base",
+            "encoder-aac-at",
+            "decoder-aac-at"
+          ]
+        }
+      ]
+    },
+    "tsc-wasm-base": {
+      "description": "The base set of features for all TSC wasm builds",
+      "dependencies": [
+        {
+          "name": "ffmpeg",
+          "default-features": false,
+          "features": [
+            "tsc-base",
+            "encoder-aac",
+            "decoder-aac",
+            "muxer-mov",
+            "muxer-mp4",
+            "demuxer-mov"
+          ]
+        }
+      ]
+    },
+    "encoder-aac": {
+      "description": "Enable encoder: aac"
+    },
+    "encoder-aac-at": {
+      "description": "Enable encoder: aac_at"
+    },
+    "encoder-aac-mf": {
+      "description": "Enable encoder: aac_mf"
+    },
+    "encoder-h264-mf": {
+      "description": "Enable encoder: h264_mf"
+    },
+    "encoder-h264-videotoolbox": {
+      "description": "Enable encoder: h264_videotoolbox"
+    },
+    "encoder-hevc-mf": {
+      "description": "Enable encoder: hevc_mf"
+    },
+    "encoder-hevc-videotoolbox": {
+      "description": "Enable encoder: hevc_videotoolbox"
+    },
+    "encoder-mp3-mf": {
+      "description": "Enable encoder: mp3_mf"
+    },
+    "decoder-aac": {
+      "description": "Enable decoders for aac"
+    },
+    "decoder-aac-at": {
+      "description": "Enable decoder: aac_at"
+    },
+    "decoder-hevc": {
+      "description": "Enable decoder: hevc"
+    },
+    "decoder-mp3": {
+      "description": "Enable decoder: mp3*"
+    },
+    "decoder-pcm": {
+      "description": "Enable decoder: pcm*"
+    },
+    "decoder-vp8": {
+      "description": "Enable decoder: vp8"
+    },
+    "decoder-vp9": {
+      "description": "Enable decoder: vp9"
+    },
+    "muxer-matroska": {
+      "description": "Enable muxer: matroska"
+    },
+    "muxer-mov": {
+      "description": "Enable muxer: mov"
+    },
+    "muxer-mp3": {
+      "description": "Enable muxer: mp3"
+    },
+    "muxer-mp4": {
+      "description": "Enable muxer: mp4"
+    },
+    "muxer-mpegts": {
+      "description": "Enable muxer: mpegts"
+    },
+    "muxer-mkvtimestamp-v2": {
+      "description": "Enable muxer: mkvtimestamp_v2"
+    },
+    "muxer-rtp-mpegts": {
+      "description": "Enable muxer: rtp_mpegts"
+    },
+    "muxer-webm": {
+      "description": "Enable muxer: webm*"
+    },
+    "demuxer-aac": {
+      "description": "Enable demuxer: aac"
+    },
+    "demuxer-hevc": {
+      "description": "Enable demuxer: hevc"
+    },
+    "demuxer-matroska": {
+      "description": "Enable demuxer: matroska"
+    },
+    "demuxer-mov": {
+      "description": "Enable demuxer: mov"
+    },
+    "demuxer-mp3": {
+      "description": "Enable demuxer: mp3"
+    },
+    "demuxer-mpegts": {
+      "description": "Enable demuxers for: mpegts"
+    },
+    "demuxer-webm": {
+      "description": "Enable demuxer: webm*"
+    },
+    "image2": {
+      "description": "Enable muxing and demuxing images with image2"
+    },
+    "png": {
+      "description": "PNG encoding & decoding (requires zlib)",
+      "dependencies": [
+        "zlib"
+      ]
     }
   }
 }

--- a/custom-ports/ffmpeg/vcpkg.json
+++ b/custom-ports/ffmpeg/vcpkg.json
@@ -784,6 +784,8 @@
           "features": [
             "tsc-desktop-base",
             "encoder-aac-mf",
+            "encoder-h264-mf",
+            "encoder-hevc-mf",
             "encoder-mp3-mf"
           ]
         }
@@ -798,6 +800,8 @@
           "features": [
             "tsc-desktop-base",
             "encoder-aac-at",
+            "encoder-h264-videotoolbox",
+            "encoder-hevc-videotoolbox",
             "decoder-aac-at"
           ]
         }

--- a/custom-steps/ffmpeg/post-build.ps1
+++ b/custom-steps/ffmpeg/post-build.ps1
@@ -46,6 +46,7 @@ Write-Message "$(NL)Running post-build tests..."
 $finalExitCode = 0
 $testScriptArgs = @{ 
   BuildArtifactsPath = $BuildArtifactsPath
+  PackageAndFeatures = $PackageAndFeatures
   ModulesRoot = $ModulesRoot
   FFMpegExePath = $pathToFFmpegExe
   OutputDir = "test-output"

--- a/custom-steps/ffmpeg/post-build.ps1
+++ b/custom-steps/ffmpeg/post-build.ps1
@@ -42,11 +42,19 @@ if((Get-IsOnMacOS)) {
     $pathToFFmpegExe = "$pathToTools/ffmpeg"
 }
 
+# Expand/flatten feature flags, so we have them all in one big list
+$vcpkgExe = "$PSScriptRoot/../../$(Get-VcPkgExe)"
+$pathToCustomPorts = "$PSScriptRoot/../../custom-ports"
+$vcpkgCommand = "$vcpkgExe install $PackageAndFeatures --overlay-ports '$pathToCustomPorts' --dry-run"
+$dryRunOutput = Invoke-Expression $vcpkgCommand
+$ffmpegPackageAndFeaturesExpanded = ($dryRunOutput -split "`n" | Select-String -Pattern 'ffmpeg\[[^\]]+\]').Matches.Value
+
+# Run tests
 Write-Message "$(NL)Running post-build tests..."
 $finalExitCode = 0
 $testScriptArgs = @{ 
   BuildArtifactsPath = $BuildArtifactsPath
-  PackageAndFeatures = $PackageAndFeatures
+  PackageAndFeatures = $ffmpegPackageAndFeaturesExpanded
   ModulesRoot = $ModulesRoot
   FFMpegExePath = $pathToFFmpegExe
   OutputDir = "test-output"

--- a/custom-steps/ffmpeg/post-build.ps1
+++ b/custom-steps/ffmpeg/post-build.ps1
@@ -55,18 +55,19 @@ Push-Location $PSScriptRoot
 if (Test-Path $testScriptArgs.OutputDir) {
   Remove-Item -Path $testScriptArgs.OutputDir -Recurse -Force
 }
-Invoke-Powershell -FilePath "test001--query-capabilities.ps1" -ArgumentList $testScriptArgs
-$scriptReturnCode = $LASTEXITCODE
-Write-Host "$(NL)> Script exit code = $scriptReturnCode"
-if ( ($finalExitCode -eq 0) -and ($returnCode -ne 0) ) {
-    $finalExitCode = $scriptReturnCode
-}
 
-Invoke-Powershell -FilePath "test002--verify-encoding.ps1" -ArgumentList $testScriptArgs
-$scriptReturnCode = $LASTEXITCODE
-Write-Host "$(NL)> Script exit code = $scriptReturnCode"
-if ( ($finalExitCode -eq 0) -and ($returnCode -ne 0) ) {
-    $finalExitCode = $scriptReturnCode
+$testScripts = @(
+   "test001--query-capabilities.ps1"
+   "test002--verify-decoding.ps1"
+   "test003--verify-encoding.ps1"
+)
+foreach($testScript in $testScripts) {
+   Write-Message "$(NL)Running tests: $testScript..."
+   Invoke-Powershell -FilePath "$testScript" -ArgumentList $testScriptArgs
+   $scriptReturnCode = $LASTEXITCODE
+   if ( ($finalExitCode -eq 0) -and ($returnCode -ne 0) ) {
+       $finalExitCode = $scriptReturnCode
+   }
 }
 
 Pop-Location

--- a/custom-steps/ffmpeg/test001--query-capabilities.ps1
+++ b/custom-steps/ffmpeg/test001--query-capabilities.ps1
@@ -1,5 +1,6 @@
 param (
     [Parameter(Mandatory=$true)][string]$BuildArtifactsPath,
+    [Parameter(Mandatory=$true)][string]$PackageAndFeatures,
     [Parameter(Mandatory=$true)][string]$ModulesRoot,
     [Parameter(Mandatory=$true)][string]$FFMpegExePath,
     [Parameter(Mandatory=$false)][string]$OutputDir = "test-output"
@@ -32,8 +33,9 @@ $tests = @(
             " libvorbis "
             " libvpx "
             " libvpx-vp9 "
+            " png "
         )
-        NotExpectedValues = @(" hevc "," h264 ")
+        NotExpectedValues = @(" h264 ")
         IsEnabled = $true
     },
     @{
@@ -43,7 +45,6 @@ $tests = @(
             "aac_mf"
             "mp3_mf"
             "h264_mf"
-            "hevc_mf"
         )
         NotExpectedValues = @()
         IsEnabled = (Get-IsOnWindowsOS)
@@ -54,7 +55,6 @@ $tests = @(
         ExpectedValues = @(
             " aac_at "
             " h264_videotoolbox "
-            " hevc_videotoolbox "
         )
         NotExpectedValues = @()
         IsEnabled = (Get-IsOnMacOS)
@@ -66,7 +66,6 @@ $tests = @(
             " aac "
             " aac_fixed "
             " aac_latm "
-            " hevc "
             " libaom-av1 "
             " libdav1d "
             " libopus "
@@ -74,6 +73,7 @@ $tests = @(
             " libvpx "
             " libvpx-vp9 "
             " mp3 "
+            " png "
             "pcm_"
             " vp8 "
             " vp9 "
@@ -94,6 +94,7 @@ $tests = @(
         Name = "Muxers"
         CmdOption = "-muxers"
         ExpectedValues = @(
+            " image2 "
             " matroska "
             " mkvtimestamp_v2 "
             " mp3 "
@@ -110,7 +111,7 @@ $tests = @(
         CmdOption = "-demuxers"
         ExpectedValues = @(
             " aac "
-            " hevc "
+            " image2 "
             " matroska,webm "
             " mov,mp4,m4a,3gp,3g2,mj2 "
             " mp3 "
@@ -141,6 +142,51 @@ $tests = @(
         IsEnabled = (Get-IsOnMacOS)
     }
 )
+
+$features = Get-Features $PackageAndFeatures
+$tests += 
+@{
+   Name = "EncodersMacH264"
+   CmdOption = "-encoders"
+   ExpectedValues = ($features -contains "encoder-h264-videotoolbox") ? @( "h264_videotoolbox" ) : @()
+   NotExpectedValues = ($features -contains "encoder-h264-videotoolbox") ? @() : @( "h264_videotoolbox" )
+   IsEnabled = (Get-IsOnWindowsOS)
+},
+@{
+   Name = "EncodersWinH264"
+   CmdOption = "-encoders"
+   ExpectedValues = ($features -contains "encoder-h264-mf") ? @( "h264_mf" ) : @()
+   NotExpectedValues = ($features -contains "encoder-h264-mf") ? @() : @( "h264_mf" )
+   IsEnabled = (Get-IsOnWindowsOS)
+},
+@{
+   Name = "EncodersMacHEVC"
+   CmdOption = "-encoders"
+   ExpectedValues = ($features -contains "encoder-hevc-videotoolbox") ? @( "hevc_videotoolbox" ) : @()
+   NotExpectedValues = ($features -contains "encoder-hevc-videotoolbox") ? @() : @( "hevc_videotoolbox" )
+   IsEnabled = (Get-IsOnMacOS)
+},
+@{
+   Name = "EncodersMacHEVC"
+   CmdOption = "-encoders"
+   ExpectedValues = ($features -contains "encoder-hevc-videotoolbox") ? @( "hevc_videotoolbox" ) : @()
+   NotExpectedValues = ($features -contains "encoder-hevc-videotoolbox") ? @() : @( "hevc_videotoolbox" )
+   IsEnabled = (Get-IsOnMacOS)
+},
+{
+   Name = "DecodersHEVC"
+   CmdOption = "-decoders"
+   ExpectedValues = ($features -contains "decoder-hevc") ? @( " hevc " ) : @()
+   NotExpectedValues = ($features -contains "decoder-hevc") ? @() : @( " hevc " )
+   IsEnabled = $true
+},
+{
+   Name = "DemuxersHEVC"
+   CmdOption = "-demuxers"
+   ExpectedValues = ($features -contains "demuxer-hevc") ? @( " hevc " ) : @()
+   NotExpectedValues = ($features -contains "demuxer-hevc") ? @() : @( " hevc " )
+   IsEnabled = $true
+}
 
 $runMsg     = " RUN      "
 $successMsg = "       OK "

--- a/custom-steps/ffmpeg/test002--verify-decoding.ps1
+++ b/custom-steps/ffmpeg/test002--verify-decoding.ps1
@@ -1,0 +1,83 @@
+param (
+    [Parameter(Mandatory=$true)][string]$BuildArtifactsPath,
+    [Parameter(Mandatory=$true)][string]$PackageAndFeatures,
+    [Parameter(Mandatory=$true)][string]$ModulesRoot,
+    [Parameter(Mandatory=$true)][string]$FFMpegExePath,
+    [Parameter(Mandatory=$false)][string]$OutputDir = "test-output"
+)
+
+# Import modules
+$moduleNames = @("Build", "Util")
+foreach( $moduleName in $moduleNames ) {
+    if(-not (Get-Module -Name $moduleName)) {
+        Import-Module "$ModulesRoot/$moduleName" -Force -DisableNameChecking
+    }
+}
+
+if (-Not (Test-Path $OutputDir)) {
+    New-Item -ItemType Directory -Path $OutputDir
+}
+
+$ffmpegExe = "$FFMpegExePath -hide_banner"
+$tests = @()
+$features = Get-Features $PackageAndFeatures
+$resourcesDir = "$PSScriptRoot/../../resources" 
+Write-Message "Features are..."
+$features | Format-List
+
+# HEVC decode tests
+$inputVideo = "$resourcesDir/BigBuckBunnyClip-hevc-240p.mp4"
+$ffmpegCmd = "$ffmpegExe -i `"$inputVideo`" -ss 00:00:04.5 -frames:v 1"
+if($features -contains "decoder-hevc")
+{
+   $tests += 
+   @{
+      Name = "Verify decoding succeeds - MP4: hevc"
+      OutFilename = "hevc-frame.png"
+      CmdPrefix = "$ffmpegCmd"
+      ExpectedReturnCode = 0
+   }
+}
+else
+{
+   $tests += 
+   @{
+      Name = "Verify decoding fails - MP4: hevc"
+      OutFilename = "hevc-frame.png"
+      CmdPrefix = "$ffmpegCmd"
+      ExpectedReturnCode = if(Get-IsOnWindowsOS) { -22 } elseif(Get-IsOnMacOS) { 234 } else { -1 }
+   }
+}
+
+$runMsg     = " RUN      "
+$successMsg = "       OK "
+$failMsg    = "     FAIL "
+$finalExitCode = 0
+Write-Host "Running decoding tests..."
+foreach ($test in $tests) {
+    $OutFilePath = "$OutputDir/$($test.OutFilename)"
+    $cmd = "$($test.CmdPrefix) `"$OutFilePath`""
+    Write-Host "[ $runMsg ] $($test.Name) ==> $OutFilePath"
+    $startTime = Get-Date
+
+    #Write-Host ">> Executing FFMpeg command"
+    #Write-Host "$cmd"
+    Invoke-Expression $cmd
+    $cmdExitCode = $LASTEXITCODE
+
+    $expectedReturnCode = if ($test.ContainsKey('ExpectedReturnCode')) { $test.ExpectedReturnCode } else { 0 }
+    Write-Host ">> Expected return code = $expectedReturnCode.  Actual return code = $cmdExitCode"
+
+    $isSuccess = ($cmdExitCode -eq $expectedReturnCode)
+    if ( ($finalExitCode -eq 0) -and (-not $isSuccess) ) {
+        $finalExitCode = $cmdExitCode
+    }
+    $statusMsg = ($isSuccess ? $successMsg : $failMsg)
+    $failSuffix = ($isSuccess ? "" : " | CMD EXIT CODE = $cmdExitCode")
+    $totalTime = (Get-Date) - $startTime
+    Write-Host "[ $statusMsg ] $($test.Name) ($($totalTime.TotalMilliseconds) ms)$failSuffix" -ForegroundColor ($isSuccess ? "Green" : "Red")
+}
+
+Write-Host "`nEncoding tests complete."
+
+Exit $finalExitCode

--- a/custom-steps/ffmpeg/test002--verify-decoding.ps1
+++ b/custom-steps/ffmpeg/test002--verify-decoding.ps1
@@ -22,8 +22,6 @@ $ffmpegExe = "$FFMpegExePath -hide_banner"
 $tests = @()
 $features = Get-Features $PackageAndFeatures
 $resourcesDir = "$PSScriptRoot/../../resources" 
-Write-Message "Features are..."
-$features | Format-List
 
 # H.264 decode tests
 $features = Get-Features $PackageAndFeatures

--- a/custom-steps/ffmpeg/test002--verify-decoding.ps1
+++ b/custom-steps/ffmpeg/test002--verify-decoding.ps1
@@ -25,6 +25,18 @@ $resourcesDir = "$PSScriptRoot/../../resources"
 Write-Message "Features are..."
 $features | Format-List
 
+# H.264 decode tests
+$features = Get-Features $PackageAndFeatures
+$inputH264Video = "$PSScriptRoot/../../resources/BigBuckBunnyClip-h264-240p.mp4"
+$ffmpegDecodeH264FrameCmd = "$ffmpegExe -i `"$inputH264Video`" -ss 00:00:04.5 -frames:v 1"
+$tests += 
+@{
+   Name = "Verify decoding fails - MP4: h.264"
+   OutFilename = "h264-frame.png"
+   CmdPrefix = "$ffmpegDecodeH264FrameCmd"
+   ExpectedReturnCode = if(Get-IsOnWindowsOS) { -22 } elseif(Get-IsOnMacOS) { 234 } else { -1 }
+}
+
 # HEVC decode tests
 $inputVideo = "$resourcesDir/BigBuckBunnyClip-hevc-240p.mp4"
 $ffmpegCmd = "$ffmpegExe -i `"$inputVideo`" -ss 00:00:04.5 -frames:v 1"

--- a/custom-steps/ffmpeg/test003--verify-encoding.ps1
+++ b/custom-steps/ffmpeg/test003--verify-encoding.ps1
@@ -94,31 +94,6 @@ $tests = @(
     }
 )
 
-# HEVC decode tests
-$features = Get-Features $PackageAndFeatures
-$inputHevcVideo = "$PSScriptRoot/../../resources/BigBuckBunnyClip-hevc-240p.mp4"
-$ffmpegDecodeHevcFrameCmd = "$ffmpegExe -i `"$inputHevcVideo`" -ss 00:00:04.5 -frames:v 1"
-if($features -contains "decoder-hevc")
-{
-   $tests += 
-   @{
-      Name = "Verify decoding succeeds - MP4: hevc"
-      OutFilename = "hevc-frame.png"
-      CmdPrefix = "$ffmpegDecodeHevcFrameCmd"
-      ExpectedReturnCode = 0
-   }
-}
-else
-{
-   $tests += 
-   @{
-      Name = "Verify decoding fails - MP4: hevc"
-      OutFilename = "hevc-frame.png"
-      CmdPrefix = "$ffmpegDecodeHevcFrameCmd"
-      ExpectedReturnCode = if(Get-IsOnWindowsOS) { -22 } elseif(Get-IsOnMacOS) { 234 } else { -1 }
-   }
-}
-
 $runMsg     = " RUN      "
 $successMsg = "       OK "
 $failMsg    = "     FAIL "

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -3,7 +3,7 @@
     {
       "name": "ffmpeg",
       "mac": {
-        "package": "ffmpeg[core,avcodec,avdevice,avfilter,avformat,avresample,dav1d,swscale,swresample,opus,mp3lame,vpx,vorbis,aom,ffmpeg,image2,png,zlib,encoder-aac,encoder-aac-at,encoder-h264-videotoolbox,decoder-aac,decoder-aac-at,decoder-mp3,decoder-pcm,decoder-vp8,decoder-vp9,muxer-matroska,muxer-mov,muxer-mp3,muxer-mp4,muxer-mpegts,muxer-mkvtimestamp-v2,muxer-rtp-mpegts,muxer-webm,demuxer-aac,muxer-matroska,demuxer-mov,demuxer-mp3,demuxer-mpegts,demuxer-webm]",
+        "package": "ffmpeg[tsc-desktop-mac,encoder-h264-videotoolbox,encoder-hevc-videotoolbox]",
         "linkType": "dynamic",
         "buildType": "release",
         "vcpkgHash": "b2cb0da531c2f1f740045bfe7c4dac59f0b2b69c",
@@ -16,7 +16,7 @@
         }
       },
       "win": {
-        "package": "ffmpeg[core,avcodec,avdevice,avfilter,avformat,avresample,dav1d,swscale,swresample,opus,mp3lame,vpx,vorbis,aom,ffmpeg,image2,png,zlib,encoder-aac,encoder-aac-mf,encoder-h264-mf,encoder-mp3-mf,decoder-aac,decoder-aac-at,decoder-mp3,decoder-pcm,decoder-vp8,decoder-vp9,muxer-matroska,muxer-mov,muxer-mp3,muxer-mp4,muxer-mpegts,muxer-mkvtimestamp-v2,muxer-rtp-mpegts,muxer-webm,demuxer-aac,muxer-matroska,demuxer-mov,demuxer-mp3,demuxer-mpegts,demuxer-webm]",
+        "package": "ffmpeg[tsc-desktop-win,encoder-h264-mf,encoder-hevc-mf]",
         "linkType": "dynamic",
         "buildType": "release",
         "vcpkgHash": "b2cb0da531c2f1f740045bfe7c4dac59f0b2b69c",
@@ -29,7 +29,7 @@
         }
       },
       "wasm": {
-        "package": "ffmpeg[core,avcodec,avdevice,avfilter,avformat,avresample,swscale,swresample,encoder-aac,decoder-aac,muxer-mov,muxer-mp4,demuxer-mov]",
+        "package": "ffmpeg[tsc-wasm-base]",
         "linkType": "dynamic",
         "buildType": "release",
         "customTriplet": "wasm32-emscripten-dynamic",
@@ -39,7 +39,7 @@
     {
       "name": "ffmpeg-hevc",
       "mac": {
-        "package": "ffmpeg[core,avcodec,avdevice,avfilter,avformat,avresample,dav1d,swscale,swresample,opus,mp3lame,vpx,vorbis,aom,ffmpeg,image2,png,zlib,encoder-aac,encoder-aac-at,encoder-h264-videotoolbox,encoder-hevc-videotoolbox,decoder-aac,decoder-aac-at,decoder-hevc,decoder-mp3,decoder-pcm,decoder-vp8,decoder-vp9,muxer-matroska,muxer-mov,muxer-mp3,muxer-mp4,muxer-mpegts,muxer-mkvtimestamp-v2,muxer-rtp-mpegts,muxer-webm,demuxer-aac,muxer-matroska,demuxer-mov,demuxer-mp3,demuxer-mpegts,demuxer-webm]",
+        "package": "ffmpeg[tsc-desktop-mac,encoder-h264-videotoolbox,encoder-hevc-videotoolbox,decoder-hevc,demuxer-hevc]",
         "linkType": "dynamic",
         "buildType": "release",
         "vcpkgHash": "b2cb0da531c2f1f740045bfe7c4dac59f0b2b69c",
@@ -52,7 +52,7 @@
         }
       },
       "win": {
-        "package": "ffmpeg[core,avcodec,avdevice,avfilter,avformat,avresample,dav1d,swscale,swresample,opus,mp3lame,vpx,vorbis,aom,ffmpeg,image2,png,zlib,encoder-aac,encoder-aac-mf,encoder-h264-mf,encoder-hevc-mf,encoder-mp3-mf,decoder-aac,decoder-aac-at,decoder-hevc,decoder-mp3,decoder-pcm,decoder-vp8,decoder-vp9,muxer-matroska,muxer-mov,muxer-mp3,muxer-mp4,muxer-mpegts,muxer-mkvtimestamp-v2,muxer-rtp-mpegts,muxer-webm,demuxer-aac,muxer-matroska,demuxer-mov,demuxer-mp3,demuxer-mpegts,demuxer-webm]",
+        "package": "ffmpeg[tsc-desktop-win,encoder-h264-mf,encoder-hevc-mf,decoder-hevc,demuxer-hevc]",
         "linkType": "dynamic",
         "buildType": "release",
         "vcpkgHash": "b2cb0da531c2f1f740045bfe7c4dac59f0b2b69c",

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -1,7 +1,7 @@
 {
   "packages": [
     {
-      "name": "ffmpeg",
+      "name": "ffmpeg-desktop-base",
       "mac": {
         "package": "ffmpeg[tsc-desktop-mac,encoder-h264-videotoolbox,encoder-hevc-videotoolbox]",
         "linkType": "dynamic",
@@ -27,17 +27,10 @@
           "share": true,
           "tools": true
         }
-      },
-      "wasm": {
-        "package": "ffmpeg[tsc-wasm-base]",
-        "linkType": "dynamic",
-        "buildType": "release",
-        "customTriplet": "wasm32-emscripten-dynamic",
-        "vcpkgHash": "b2cb0da531c2f1f740045bfe7c4dac59f0b2b69c"
       }
     },
     {
-      "name": "ffmpeg-hevc",
+      "name": "ffmpeg-desktop-hevc",
       "mac": {
         "package": "ffmpeg[tsc-desktop-mac,encoder-h264-videotoolbox,encoder-hevc-videotoolbox,decoder-hevc,demuxer-hevc]",
         "linkType": "dynamic",
@@ -63,6 +56,16 @@
           "share": true,
           "tools": true
         }
+      }
+    },
+    {
+      "name": "ffmpeg-wasm-base",
+      "wasm": {
+        "package": "ffmpeg[tsc-wasm-base]",
+        "linkType": "dynamic",
+        "buildType": "release",
+        "customTriplet": "wasm32-emscripten-dynamic",
+        "vcpkgHash": "b2cb0da531c2f1f740045bfe7c4dac59f0b2b69c"
       }
     },
     {

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -3,7 +3,7 @@
     {
       "name": "ffmpeg-desktop-base",
       "mac": {
-        "package": "ffmpeg[tsc-desktop-mac,encoder-h264-videotoolbox,encoder-hevc-videotoolbox]",
+        "package": "ffmpeg[tsc-desktop-mac]",
         "linkType": "dynamic",
         "buildType": "release",
         "vcpkgHash": "b2cb0da531c2f1f740045bfe7c4dac59f0b2b69c",
@@ -16,7 +16,7 @@
         }
       },
       "win": {
-        "package": "ffmpeg[tsc-desktop-win,encoder-h264-mf,encoder-hevc-mf]",
+        "package": "ffmpeg[tsc-desktop-win]",
         "linkType": "dynamic",
         "buildType": "release",
         "vcpkgHash": "b2cb0da531c2f1f740045bfe7c4dac59f0b2b69c",
@@ -32,7 +32,7 @@
     {
       "name": "ffmpeg-desktop-hevc",
       "mac": {
-        "package": "ffmpeg[tsc-desktop-mac,encoder-h264-videotoolbox,encoder-hevc-videotoolbox,decoder-hevc,demuxer-hevc]",
+        "package": "ffmpeg[tsc-desktop-mac,decoder-hevc,demuxer-hevc]",
         "linkType": "dynamic",
         "buildType": "release",
         "vcpkgHash": "b2cb0da531c2f1f740045bfe7c4dac59f0b2b69c",
@@ -45,7 +45,7 @@
         }
       },
       "win": {
-        "package": "ffmpeg[tsc-desktop-win,encoder-h264-mf,encoder-hevc-mf,decoder-hevc,demuxer-hevc]",
+        "package": "ffmpeg[tsc-desktop-win,decoder-hevc,demuxer-hevc]",
         "linkType": "dynamic",
         "buildType": "release",
         "vcpkgHash": "b2cb0da531c2f1f740045bfe7c4dac59f0b2b69c",

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -3,7 +3,7 @@
     {
       "name": "ffmpeg",
       "mac": {
-        "package": "ffmpeg[core,avcodec,avdevice,avfilter,avformat,avresample,dav1d,swscale,swresample,opus,mp3lame,vpx,vorbis,aom,ffmpeg,encoder-aac,encoder-aac-at,encoder-h264-videotoolbox,decoder-aac,decoder-aac-at,decoder-mp3,decoder-pcm,decoder-vp8,decoder-vp9,muxer-matroska,muxer-mov,muxer-mp3,muxer-mp4,muxer-mpegts,muxer-mkvtimestamp-v2,muxer-rtp-mpegts,muxer-webm,demuxer-aac,demuxer-matroska,demuxer-mov,demuxer-mp3,demuxer-mpegts,demuxer-webm]",
+        "package": "ffmpeg[core,avcodec,avdevice,avfilter,avformat,avresample,dav1d,swscale,swresample,opus,mp3lame,vpx,vorbis,aom,ffmpeg,image2,png,zlib,encoder-aac,encoder-aac-at,encoder-h264-videotoolbox,decoder-aac,decoder-aac-at,decoder-mp3,decoder-pcm,decoder-vp8,decoder-vp9,muxer-matroska,muxer-mov,muxer-mp3,muxer-mp4,muxer-mpegts,muxer-mkvtimestamp-v2,muxer-rtp-mpegts,muxer-webm,demuxer-aac,muxer-matroska,demuxer-mov,demuxer-mp3,demuxer-mpegts,demuxer-webm]",
         "linkType": "dynamic",
         "buildType": "release",
         "vcpkgHash": "b2cb0da531c2f1f740045bfe7c4dac59f0b2b69c",
@@ -16,7 +16,7 @@
         }
       },
       "win": {
-        "package": "ffmpeg[core,avcodec,avdevice,avfilter,avformat,avresample,dav1d,swscale,swresample,opus,mp3lame,vpx,vorbis,aom,ffmpeg,encoder-aac,encoder-aac-mf,encoder-h264-mf,encoder-mp3-mf,decoder-aac,decoder-aac-at,decoder-mp3,decoder-pcm,decoder-vp8,decoder-vp9,muxer-matroska,muxer-mov,muxer-mp3,muxer-mp4,muxer-mpegts,muxer-mkvtimestamp-v2,muxer-rtp-mpegts,muxer-webm,demuxer-aac,demuxer-matroska,demuxer-mov,demuxer-mp3,demuxer-mpegts,demuxer-webm]",
+        "package": "ffmpeg[core,avcodec,avdevice,avfilter,avformat,avresample,dav1d,swscale,swresample,opus,mp3lame,vpx,vorbis,aom,ffmpeg,image2,png,zlib,encoder-aac,encoder-aac-mf,encoder-h264-mf,encoder-mp3-mf,decoder-aac,decoder-aac-at,decoder-mp3,decoder-pcm,decoder-vp8,decoder-vp9,muxer-matroska,muxer-mov,muxer-mp3,muxer-mp4,muxer-mpegts,muxer-mkvtimestamp-v2,muxer-rtp-mpegts,muxer-webm,demuxer-aac,muxer-matroska,demuxer-mov,demuxer-mp3,demuxer-mpegts,demuxer-webm]",
         "linkType": "dynamic",
         "buildType": "release",
         "vcpkgHash": "b2cb0da531c2f1f740045bfe7c4dac59f0b2b69c",
@@ -39,7 +39,7 @@
     {
       "name": "ffmpeg-hevc",
       "mac": {
-        "package": "ffmpeg[core,avcodec,avdevice,avfilter,avformat,avresample,dav1d,swscale,swresample,opus,mp3lame,vpx,vorbis,aom,ffmpeg,encoder-aac,encoder-aac-at,encoder-h264-videotoolbox,encoder-hevc-videotoolbox,decoder-aac,decoder-aac-at,decoder-hevc,decoder-mp3,decoder-pcm,decoder-vp8,decoder-vp9,muxer-matroska,muxer-mov,muxer-mp3,muxer-mp4,muxer-mpegts,muxer-mkvtimestamp-v2,muxer-rtp-mpegts,muxer-webm,demuxer-aac,demuxer-matroska,demuxer-mov,demuxer-mp3,demuxer-mpegts,demuxer-webm]",
+        "package": "ffmpeg[core,avcodec,avdevice,avfilter,avformat,avresample,dav1d,swscale,swresample,opus,mp3lame,vpx,vorbis,aom,ffmpeg,image2,png,zlib,encoder-aac,encoder-aac-at,encoder-h264-videotoolbox,encoder-hevc-videotoolbox,decoder-aac,decoder-aac-at,decoder-hevc,decoder-mp3,decoder-pcm,decoder-vp8,decoder-vp9,muxer-matroska,muxer-mov,muxer-mp3,muxer-mp4,muxer-mpegts,muxer-mkvtimestamp-v2,muxer-rtp-mpegts,muxer-webm,demuxer-aac,muxer-matroska,demuxer-mov,demuxer-mp3,demuxer-mpegts,demuxer-webm]",
         "linkType": "dynamic",
         "buildType": "release",
         "vcpkgHash": "b2cb0da531c2f1f740045bfe7c4dac59f0b2b69c",
@@ -52,7 +52,7 @@
         }
       },
       "win": {
-        "package": "ffmpeg[core,avcodec,avdevice,avfilter,avformat,avresample,dav1d,swscale,swresample,opus,mp3lame,vpx,vorbis,aom,ffmpeg,encoder-aac,encoder-aac-mf,encoder-h264-mf,encoder-hevc-mf,encoder-mp3-mf,decoder-aac,decoder-aac-at,decoder-hevc,decoder-mp3,decoder-pcm,decoder-vp8,decoder-vp9,muxer-matroska,muxer-mov,muxer-mp3,muxer-mp4,muxer-mpegts,muxer-mkvtimestamp-v2,muxer-rtp-mpegts,muxer-webm,demuxer-aac,demuxer-matroska,demuxer-mov,demuxer-mp3,demuxer-mpegts,demuxer-webm]",
+        "package": "ffmpeg[core,avcodec,avdevice,avfilter,avformat,avresample,dav1d,swscale,swresample,opus,mp3lame,vpx,vorbis,aom,ffmpeg,image2,png,zlib,encoder-aac,encoder-aac-mf,encoder-h264-mf,encoder-hevc-mf,encoder-mp3-mf,decoder-aac,decoder-aac-at,decoder-hevc,decoder-mp3,decoder-pcm,decoder-vp8,decoder-vp9,muxer-matroska,muxer-mov,muxer-mp3,muxer-mp4,muxer-mpegts,muxer-mkvtimestamp-v2,muxer-rtp-mpegts,muxer-webm,demuxer-aac,muxer-matroska,demuxer-mov,demuxer-mp3,demuxer-mpegts,demuxer-webm]",
         "linkType": "dynamic",
         "buildType": "release",
         "vcpkgHash": "b2cb0da531c2f1f740045bfe7c4dac59f0b2b69c",

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -3,7 +3,7 @@
     {
       "name": "ffmpeg",
       "mac": {
-        "package": "ffmpeg[core,avcodec,avdevice,avfilter,avformat,avresample,dav1d,swscale,swresample,opus,mp3lame,vpx,vorbis,aom,ffmpeg]",
+        "package": "ffmpeg[core,avcodec,avdevice,avfilter,avformat,avresample,dav1d,swscale,swresample,opus,mp3lame,vpx,vorbis,aom,ffmpeg,encoder-aac,encoder-aac-at,encoder-h264-videotoolbox,decoder-aac,decoder-aac-at,decoder-mp3,decoder-pcm,decoder-vp8,decoder-vp9,muxer-matroska,muxer-mov,muxer-mp3,muxer-mp4,muxer-mpegts,muxer-mkvtimestamp-v2,muxer-rtp-mpegts,muxer-webm,demuxer-aac,demuxer-matroska,demuxer-mov,demuxer-mp3,demuxer-mpegts,demuxer-webm]",
         "linkType": "dynamic",
         "buildType": "release",
         "vcpkgHash": "b2cb0da531c2f1f740045bfe7c4dac59f0b2b69c",
@@ -16,7 +16,7 @@
         }
       },
       "win": {
-        "package": "ffmpeg[core,avcodec,avdevice,avfilter,avformat,avresample,dav1d,swscale,swresample,opus,mp3lame,vpx,vorbis,aom,ffmpeg]",
+        "package": "ffmpeg[core,avcodec,avdevice,avfilter,avformat,avresample,dav1d,swscale,swresample,opus,mp3lame,vpx,vorbis,aom,ffmpeg,encoder-aac,encoder-aac-mf,encoder-h264-mf,encoder-mp3-mf,decoder-aac,decoder-aac-at,decoder-mp3,decoder-pcm,decoder-vp8,decoder-vp9,muxer-matroska,muxer-mov,muxer-mp3,muxer-mp4,muxer-mpegts,muxer-mkvtimestamp-v2,muxer-rtp-mpegts,muxer-webm,demuxer-aac,demuxer-matroska,demuxer-mov,demuxer-mp3,demuxer-mpegts,demuxer-webm]",
         "linkType": "dynamic",
         "buildType": "release",
         "vcpkgHash": "b2cb0da531c2f1f740045bfe7c4dac59f0b2b69c",
@@ -29,11 +29,40 @@
         }
       },
       "wasm": {
-        "package": "ffmpeg[core,avcodec,avdevice,avfilter,avformat,avresample,swscale,swresample]",
+        "package": "ffmpeg[core,avcodec,avdevice,avfilter,avformat,avresample,swscale,swresample,encoder-aac,decoder-aac,muxer-mov,muxer-mp4,demuxer-mov]",
         "linkType": "dynamic",
         "buildType": "release",
         "customTriplet": "wasm32-emscripten-dynamic",
         "vcpkgHash": "b2cb0da531c2f1f740045bfe7c4dac59f0b2b69c"
+      }
+    },
+    {
+      "name": "ffmpeg-hevc",
+      "mac": {
+        "package": "ffmpeg[core,avcodec,avdevice,avfilter,avformat,avresample,dav1d,swscale,swresample,opus,mp3lame,vpx,vorbis,aom,ffmpeg,encoder-aac,encoder-aac-at,encoder-h264-videotoolbox,encoder-hevc-videotoolbox,decoder-aac,decoder-aac-at,decoder-hevc,decoder-mp3,decoder-pcm,decoder-vp8,decoder-vp9,muxer-matroska,muxer-mov,muxer-mp3,muxer-mp4,muxer-mpegts,muxer-mkvtimestamp-v2,muxer-rtp-mpegts,muxer-webm,demuxer-aac,demuxer-matroska,demuxer-mov,demuxer-mp3,demuxer-mpegts,demuxer-webm]",
+        "linkType": "dynamic",
+        "buildType": "release",
+        "vcpkgHash": "b2cb0da531c2f1f740045bfe7c4dac59f0b2b69c",
+        "publish": {
+          "include": true,
+          "lib": true,
+          "bin": true,
+          "share": true,
+          "tools": true
+        }
+      },
+      "win": {
+        "package": "ffmpeg[core,avcodec,avdevice,avfilter,avformat,avresample,dav1d,swscale,swresample,opus,mp3lame,vpx,vorbis,aom,ffmpeg,encoder-aac,encoder-aac-mf,encoder-h264-mf,encoder-hevc-mf,encoder-mp3-mf,decoder-aac,decoder-aac-at,decoder-hevc,decoder-mp3,decoder-pcm,decoder-vp8,decoder-vp9,muxer-matroska,muxer-mov,muxer-mp3,muxer-mp4,muxer-mpegts,muxer-mkvtimestamp-v2,muxer-rtp-mpegts,muxer-webm,demuxer-aac,demuxer-matroska,demuxer-mov,demuxer-mp3,demuxer-mpegts,demuxer-webm]",
+        "linkType": "dynamic",
+        "buildType": "release",
+        "vcpkgHash": "b2cb0da531c2f1f740045bfe7c4dac59f0b2b69c",
+        "publish": {
+          "include": true,
+          "lib": true,
+          "bin": true,
+          "share": true,
+          "tools": true
+        }
       }
     },
     {

--- a/resources/BigBuckBunnyClip-h264-240p.mp4
+++ b/resources/BigBuckBunnyClip-h264-240p.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb21aebb7bf1eea1568b8c3b3202abd1eb999a8e387d473490fe522dc0719e3d
+size 182115

--- a/resources/BigBuckBunnyClip-vp9-240p.mp4
+++ b/resources/BigBuckBunnyClip-vp9-240p.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:690d072be9bf61c43729c04ba376ee3f9ffb83889fdb34bf1c7921bb30a93a85
+size 161392

--- a/scripts/ps-modules/Build/Build.psm1
+++ b/scripts/ps-modules/Build/Build.psm1
@@ -325,7 +325,7 @@ function Run-PrestageAndFinalizeBuildArtifactsStep {
 
    # If we're on MacOS and we didn't specify a custom triplet, we're building a universal binary
    # If we specify a custom triplet, we can only build one architecture at a time
-   $isUniversalBinary = ((Get-IsOnMacOS) -and ($customTriplet -eq ""))
+   $isUniversalBinary = ((Get-IsOnMacOS) -and ($triplets.Count -eq 2))
 
    # Get dirs to copy
    $srcToDestDirs = @{}

--- a/scripts/ps-modules/Build/Build.psm1
+++ b/scripts/ps-modules/Build/Build.psm1
@@ -11,7 +11,7 @@ function Install-FromVcpkg {
 
     $pkgToInstall = "${packageAndFeatures}:${triplet}"
     Write-Message "Installing package: `"$pkgToInstall`""
-    Invoke-Expression "$(Get-VcPkgExe) install `"$pkgToInstall`" --overlay-triplets=`"custom-triplets`" --overlay-ports=`"custom-ports`""
+    Invoke-Expression "./$(Get-VcPkgExe) install `"$pkgToInstall`" --overlay-triplets=`"custom-triplets`" --overlay-ports=`"custom-ports`""
 }
 
 function Get-PackageNameOnly {
@@ -48,9 +48,9 @@ function Get-PreStagePath {
 
 function Get-VcPkgExe {
    if ( (Get-IsOnWindowsOS) ) {
-      return "./vcpkg/vcpkg.exe"
+      return "vcpkg/vcpkg.exe"
    } elseif ( (Get-IsOnMacOS) -or (Get-IsOnLinux) ) {
-      return "./vcpkg/vcpkg"
+      return "vcpkg/vcpkg"
    }
    throw [System.Exception]::new("Invalid OS")
 }
@@ -439,7 +439,7 @@ function Run-StageBuildArtifactsStep {
 
    $dependenciesFilename = "dependencies.json"
    Write-Message "Generating: `"$dependenciesFilename`"..."
-   Invoke-Expression "$(Get-VcPkgExe) list --x-json > $stagedArtifactSubDir/$artifactName/$dependenciesFilename"
+   Invoke-Expression "./$(Get-VcPkgExe) list --x-json > $stagedArtifactSubDir/$artifactName/$dependenciesFilename"
 
    $packageInfoFilename = "package.json"
    Write-Message "Generating: `"$packageInfoFilename`"..."
@@ -529,7 +529,7 @@ function Resolve-Symlink {
 }
 
 Export-ModuleMember -Function Get-PackageInfo, Run-WriteParamsStep, Run-SetupVcpkgStep, Run-PreBuildStep, Run-InstallCompilerIfNecessary, Run-InstallPackageStep, Run-PrestageAndFinalizeBuildArtifactsStep, Run-PostBuildStep, Run-StageBuildArtifactsStep, Run-StageSourceArtifactsStep, Run-CleanupStep, Get-Triplets
-Export-ModuleMember -Function NL, Write-Banner, Write-Message, Check-IsEmscriptenBuild, Get-PSObjectAsFormattedList, Get-IsOnMacOS, Get-IsOnWindowsOS, Get-IsOnLinux, Get-OSType, Resolve-Symlink
+Export-ModuleMember -Function NL, Write-Banner, Write-Message, Check-IsEmscriptenBuild, Get-PSObjectAsFormattedList, Get-IsOnMacOS, Get-IsOnWindowsOS, Get-IsOnLinux, Get-OSType, Get-VcPkgExe, Resolve-Symlink
 
 if ( (Get-IsOnMacOS) ) {
    Import-Module "$PSScriptRoot/../../ps-modules/MacBuild" -DisableNameChecking -Force

--- a/scripts/ps-modules/Util/Util.psm1
+++ b/scripts/ps-modules/Util/Util.psm1
@@ -176,4 +176,15 @@ function Run-ScriptIfExists {
    Invoke-Powershell -FilePath $script -ArgumentList $scriptArgs
 }
 
-Export-ModuleMember -Function Show-FileContent, Install-FromVcpkg, Exit-IfError, Write-ReleaseInfoJson, Get-IsOnMacOS, Get-IsOnWindowsOS, Get-IsOnLinux, Get-OSType, Invoke-Powershell, Write-Banner, Write-Message, Write-Debug, NL, Get-PSObjectAsFormattedList, Run-ScriptIfExists
+function Get-Features {
+   param(
+      [string]$packageAndFeatures
+   )
+   if($packageAndFeatures -match '\[(.*?)\]')
+   {
+      return ($matches[1] -split ",")
+   }
+   return $()
+}
+
+Export-ModuleMember -Function Show-FileContent, Install-FromVcpkg, Exit-IfError, Write-ReleaseInfoJson, Get-IsOnMacOS, Get-IsOnWindowsOS, Get-IsOnLinux, Get-OSType, Invoke-Powershell, Write-Banner, Write-Message, Write-Debug, NL, Get-Features, Get-PSObjectAsFormattedList, Run-ScriptIfExists

--- a/scripts/ps-modules/Util/Util.psm1
+++ b/scripts/ps-modules/Util/Util.psm1
@@ -78,8 +78,6 @@ function Invoke-Powershell {
         $type = if($isValueAnArray) { "string[]" } else { $value.GetType().Name }
         $paramArray += "[${type}]`$$key"
         if($isValueAnArray) {
-           Write-Host "$key is array!"
-           $value | Format-List
            $namedParamStrings += "-$key $($value -join ",")"
         }
         else {


### PR DESCRIPTION
# Description
We have to pay money to a patent pool in order to ship an hevc decoder with our commercial products.  Because of this, we need to be able to ship some products _with_ an hevc decoder and some _without_ this decoder, as this is an overhead cost we only need to incur for some products that actually need this decoder.

This PR creates 2 different preconfigured builds, using the same custom ffmpeg overlay port, so that we can do this.

## Additional information
I have updated the tests to verify that the decoding happens for the port we want it to happen on and does not happen for the port we do not want it to happen on.  This required enabling png support, so that we could test exporting frames to pngs.