### PR TITLE
Update libmp3lame.dll version

### DIFF
--- a/custom-steps/ffmpeg/version-info.json
+++ b/custom-steps/ffmpeg/version-info.json
@@ -49,6 +49,10 @@
             "copyright": "Copyright (C) 2000-2023 FFmpeg Project"
         },
         {
+            "filename": "bin/libmp3lame.dll",
+            "fileVersion": "3.100.2.17"
+        },
+        {
             "filename": "bin/ogg.dll",
             "fileDescription": "A library for manipulating ogg bitstreams.",
             "fileVersion": "1.3.5",


### PR DESCRIPTION
# Description
This updates the libmp3lame.dll version to 3.100.2.17.

The actual version when we built it with FFmpeg was 3.100.2.0 in FFmpeg 6.1.1, and that was also the version in the previous build of FFmpeg we used.  We need to update this dll version number every time to something greater, however, or the CWin upgrade tests will fail.  

We previously had it updating to 3.100.2.16, but I accidentally removed that in 41fd13ad89cf2b95ba3b4956514b14accbe9fca1.  This adds this back and updates the version number to 3.100.2.17, so that the upgrade tests will succeed.

# Testing

https://github.com/user-attachments/assets/c5be8547-de79-42c1-90eb-c7038c70eb88

