### PR TITLE
Update Pango version metadata

### DIFF
--- a/custom-steps/pango/version-info.json
+++ b/custom-steps/pango/version-info.json
@@ -3,7 +3,7 @@
     {
       "filename": "bin/brotlicommon.dll",
       "fileDescription": "Brotli common dictionary library",
-      "fileVersion": "1.1.0",
+      "fileVersion": "1.1.0.100",
       "productName": "Brotli",
       "productVersion": "1.1.0",
       "copyright": "Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors."
@@ -11,7 +11,7 @@
     {
       "filename": "bin/brotlidec.dll",
       "fileDescription": "Brotli decoder library",
-      "fileVersion": "1.1.0",
+      "fileVersion": "1.1.0.100",
       "productName": "Brotli",
       "productVersion": "1.1.0",
       "copyright": "Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors."
@@ -19,7 +19,7 @@
     {
       "filename": "bin/brotlienc.dll",
       "fileDescription": "Brotli encoder library",
-      "fileVersion": "1.1.0",
+      "fileVersion": "1.1.0.100",
       "productName": "Brotli",
       "productVersion": "1.1.0",
       "copyright": "Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors."
@@ -27,7 +27,7 @@
     {
       "filename": "bin/bz2.dll",
       "fileDescription": "A program and library for lossless, block-sorting data compression",
-      "fileVersion": "1.0.8",
+      "fileVersion": "1.0.8.100",
       "productName": "Bzip2",
       "productVersion": "1.0.8",
       "copyright": "Copyright (C) 1996-2019 Julian R Seward"
@@ -59,7 +59,7 @@
     {
       "filename": "bin/charset-1.dll",
       "fileDescription": "libcharset",
-      "fileVersion": "1.5",
+      "fileVersion": "1.5.0.100",
       "productName": "libiconv: character set conversion library",
       "productVersion": "1.17.0.0",
       "copyright": "Copyright (C) 1999-2022"
@@ -81,6 +81,14 @@
       "copyright": "Copyright (c) 2000-2020 Keith Packard, Patrick Lam and others"
     },
     {
+      "filename": "bin/freetype.dll",
+      "fileDescription": "Font Rendering Library",
+      "fileVersion": "2.13.3",
+      "productName": "FreeType",
+      "productVersion": "2.13.3",
+      "copyright": "© 2000-2024 The FreeType Project www.freetype.org. All rights reserved."
+    },
+    {
       "filename": "bin/fribidi-0.dll",
       "fileDescription": "Unicode Bidirectional Algorithm Library",
       "fileVersion": "1.0.16",
@@ -89,12 +97,52 @@
       "copyright": "Copyright (C) 2004 Sharif FarsiWeb, Inc"
     },
     {
+      "filename": "bin/gio-2.0-0.dll",
+      "fileDescription": "Gio",
+      "fileVersion": "2.80.0.0",
+      "productName": "GLib",
+      "productVersion": "2.80.0",
+      "copyright": "Copyright 2006-2011 Red Hat, Inc. and others."
+    },
+    {
       "filename": "bin/girepository-2.0-0.dll",
       "fileDescription": "GObject Introspection repository parser",
       "fileVersion": "2.80.0.0",
       "productName": "GLib",
       "productVersion": "2.80.0",
       "copyright": "Copyright (C) 2005-2025 Matthias Clasen, Red Hat, Inc. and others"
+    },
+    {
+      "filename": "bin/glib-2.0-0.dll",
+      "fileDescription": "GLib",
+      "fileVersion": "2.80.0.0",
+      "productName": "GLib",
+      "productVersion": "2.80.0",
+      "copyright": "Copyright 1995-2011 Peter Mattis, Spencer Kimball, Josh MacDonald and others."
+    },
+    {
+      "filename": "bin/gmodule-2.0-0.dll",
+      "fileDescription": "GModule",
+      "fileVersion": "2.80.0.0",
+      "productName": "GLib",
+      "productVersion": "2.80.0",
+      "copyright": "Copyright 1998-2011 Tim Janik and others."
+    },
+    {
+      "filename": "bin/gobject-2.0-0.dll",
+      "fileDescription": "GObject",
+      "fileVersion": "2.80.0.0",
+      "productName": "GLib",
+      "productVersion": "2.80.0",
+      "copyright": "Copyright 1998-2011 Tim Janik, Red Hat, Inc. and others"
+    },
+    {
+      "filename": "bin/gthread-2.0-0.dll",
+      "fileDescription": "GThread",
+      "fileVersion": "2.80.0.0",
+      "productName": "GLib",
+      "productVersion": "2.80.0",
+      "copyright": "Copyright 1995-2011 Peter Mattis, Spencer Kimball, Josh MacDonald, Sebastian Wilhelmi and others."
     },
     {
       "filename": "bin/harfbuzz-subset.dll",
@@ -113,9 +161,27 @@
       "copyright": "Copyright © 2010-2022 Google, Inc. and others"
     },
     {
+      "filename": "bin/iconv-2.dll",
+      "fileDescription": "LGPLed libiconv for Windows",
+      "fileVersion": "1.17.0.100",
+      "productName": "libiconv: character set conversion library",
+      "productVersion": "1.17",
+      "copyright": "Copyright (C) 1999-2022"
+    },
+    {
+      "filename": "bin/intl-8.dll",
+      "fileDescription": "LGPLed libintl for Windows",
+      "fileVersion": "0.22.5",
+      "productName": "GNU libintl: accessing NLS message catalogs",
+      "productVersion": "0.22.5",
+      "copyright": "Copyright (C) 1995-2019"
+    },
+    {
       "filename": "bin/libexpat.dll",
       "fileDescription": "Expat XML parser",
+      "fileVersion": "2.6.4.0",
       "productName": "Expat",
+      "productVersion": "2.6.4.0",
       "copyright": "Copyright (c) 2001-2022 Expat maintainers"
     },
     {
@@ -125,6 +191,38 @@
       "productName": "libpng",
       "productVersion": "1.6.45",
       "copyright": "Copyright (c) 1995-2025 The PNG Reference Library Authors."
+    },
+    {
+      "filename": "bin/pango-1.0-0.dll",
+      "fileDescription": "Pango",
+      "fileVersion": "1.56.1.0",
+      "productName": "Pango",
+      "productVersion": "1.56.1",
+      "copyright": "Copyright 1999 Red Hat Software."
+    },
+    {
+      "filename": "bin/pangocairo-1.0-0.dll",
+      "fileDescription": "PangoCairo",
+      "fileVersion": "1.56.1.0",
+      "productName": "PangoCairo",
+      "productVersion": "1.56.1",
+      "copyright": "Copyright 2010 Red Hat Software."
+    },
+    {
+      "filename": "bin/pangoft2-1.0-0.dll",
+      "fileDescription": "PangoFT2",
+      "fileVersion": "1.56.1.0",
+      "productName": "PangoFT2",
+      "productVersion": "1.56.1",
+      "copyright": "Copyright 1999 Red Hat Software. Copyright 2000 Tor Lillqvist"
+    },
+    {
+      "filename": "bin/pangowin32-1.0-0.dll",
+      "fileDescription": "PangoWin32",
+      "fileVersion": "1.56.1.0",
+      "productName": "PangoWin32",
+      "productVersion": "1.56.1",
+      "copyright": "Copyright 1999 Red Hat Software. Copyright 2000 Tor Lillqvist"
     },
     {
       "filename": "bin/pcre2-16.dll",
@@ -165,6 +263,38 @@
       "productName": "Pixman",
       "productVersion": "0.43.4",
       "copyright": "Copyright (c) 1997-2010 Red Hat, Inc. and others"
+    },
+    {
+      "filename": "bin/pthreadVC3.dll",
+      "fileDescription": "MS C x64",
+      "fileVersion": "3, 0, 0, 100",
+      "productName": "POSIX Threads for Windows",
+      "productVersion": "3, 0, 0, 0",
+      "copyright": "Copyright - Project contributors 1999-2016"
+    },
+    {
+      "filename": "bin/pthreadVCE3.dll",
+      "fileDescription": "MS C++ x64",
+      "fileVersion": "3, 0, 0, 100",
+      "productName": "POSIX Threads for Windows",
+      "productVersion": "3, 0, 0, 0",
+      "copyright": "Copyright - Project contributors 1999-2016"
+    },
+    {
+      "filename": "bin/pthreadVSE3.dll",
+      "fileDescription": "MS C SEH x64",
+      "fileVersion": "3, 0, 0, 100",
+      "productName": "POSIX Threads for Windows",
+      "productVersion": "3, 0, 0, 0",
+      "copyright": "Copyright - Project contributors 1999-2016"
+    },
+    {
+      "filename": "bin/zlib1.dll",
+      "fileDescription": "zlib data compression library",
+      "fileVersion": "1.3.1.100",
+      "productName": "zlib",
+      "productVersion": "1.3.1",
+      "copyright": "(C) 1995-2022 Jean-loup Gailly & Mark Adler"
     }
   ]
 }

--- a/scripts/tools/create-version-info.json.ps1
+++ b/scripts/tools/create-version-info.json.ps1
@@ -1,0 +1,41 @@
+param (
+    [Parameter(Mandatory=$true)]
+    [string]$InputDllDir,
+
+    [Parameter(Mandatory=$true)]
+    [string]$OutputJsonFile
+)
+
+function Replace-NullWithEmptyString {
+    param (
+        [Parameter(Mandatory=$true)]
+        [PSCustomObject]$object
+    )
+
+    $object.PSObject.Properties | ForEach-Object {
+        if ($_.Value -eq $null) {
+            $_.Value = ""
+        }
+    }
+    return $object
+}
+
+$filenamePrefix = "bin/"
+$results = Get-ChildItem -Path "$InputDllDir/" -Filter "*.dll" | ForEach-Object {
+    $versionInfo = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($_.FullName)
+    $dllInfo = [PSCustomObject]@{
+        filename        = "$filenamePrefix$($_.Name)"
+        fileDescription = $versionInfo.FileDescription
+        fileVersion     = $versionInfo.FileVersion
+        productName     = $versionInfo.ProductName
+        productVersion  = $versionInfo.ProductVersion
+        copyright       = $versionInfo.LegalCopyright
+    }
+    Replace-NullWithEmptyString -object $dllInfo
+}
+
+$jsonOutput = @{
+    files = $results
+} | ConvertTo-Json -Depth 3
+
+$jsonOutput | Set-Content -Path $OutputJsonFile


### PR DESCRIPTION
# Description
Some clients have installer issues if the file versions do not change when the dlls change.  To avoid this, I am manually appending ".100" as the 4th part of the version number, similar to what we do for FFmpeg when things like libmp3lame do not get updated.

This change has been made for:
- bin/brotlicommon.dll
- bin/brotlidec.dll
- bin/brotlienc.dll
- bin/bz2.dll
- bin/charset-1.dll
- bin/pthreadVC3.dll
- bin/pthreadVCE3.dll
- bin/pthreadVSE3.dll
- bin/zlib1.dll

Additionally, now that we have a script to generate this version-info.json file, I've added back the other files that are actually versioned correctly coming out of vcpkg, so that we can easily detect if those file versions have changed between builds of pango & friends.

I have done this for these libraries:
- bin/freetype.dll
- bin/gio-2.0-0.dll
- bin/glib-2.0-0.dll
- bin/gmodule-2.0-0.dll
- bin/gobject-2.0-0.dll
- bin/gthread-2.0-0.dll
- bin/iconv-2.dll <== also required a version update to .100!
- bin/intl-8.dll
- bin/libexpat.dll <== previously set version metadata successfully, but not other metadata
- bin/pango-1.0-0.dll
- bin/pangocairo-1.0-0.dll
- bin/pangoft2-1.0-0.dll
- bin/pangowin32-1.0-0.dll
- bin/pthreadVC3.dll <== also required a version update to .100!
- bin/pthreadVCE3.dll <== also required a version update to .100!
- bin/pthreadVSE3.dll <== also required a version update to .100!
- bin/zlib1.dll <== also required a version update to .100!

# Testing
- [x] Create build from this branch and [download the artifact](https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_build/results?buildId=441168&view=artifacts&pathAsName=false&type=publishedArtifacts) in `win-bin`
- [x] Run the tool to generate the version-info.json file from the dll metadata: 
```
$pathToDlls = "$env:USERPROFILE\Downloads\pango-desktop-windows--bin\bin"
$pathToJsonOutputFile = "../../custom-steps/pango/version-info-branch.json"
cd scripts/tools
./create-version-info.json.ps1 -InputDllDir $pathToDlls -OutputJsonFile $pathToJsonOutputFile
```
- [x] diff `custom-steps/pango/version-info.json` with `custom-steps/pango/version-info-branch.json` and verify they are the same (minus possible line ending differences).