### PR TITLE
Create a new image2video focused build of ffmpeg wasm

### DIFF
--- a/.pipelines/build-package-preconfigured.yml
+++ b/.pipelines/build-package-preconfigured.yml
@@ -15,6 +15,7 @@ parameters:
   - ffmpeg-desktop-base
   - ffmpeg-desktop-hevc
   - ffmpeg-wasm-base
+  - ffmpeg-wasm-image2video
   - glslang
   - hunspell
   - hunspell-debug

--- a/custom-ports/ffmpeg/portfile.cmake
+++ b/custom-ports/ffmpeg/portfile.cmake
@@ -177,6 +177,7 @@ set(FEATURE_DEMUXER_MAP
    "demuxer-mp3=mp3"
    "demuxer-mpegts=mpegts,mpegtsraw"
    "demuxer-webm=webm*"
+   "demuxer-wav=wav"
    "image2=image2"
 )
 map_features_to_items("${FEATURE_DEMUXER_MAP}" "${FEATURES}" TSC_DEMUXERS)

--- a/custom-ports/ffmpeg/vcpkg.json
+++ b/custom-ports/ffmpeg/vcpkg.json
@@ -824,10 +824,12 @@
             "decoder-aac",
             "decoder-vp9",
             "decoder-mp3",
+            "decoder-pcm",
             "muxer-mov",
             "muxer-mp4",
             "demuxer-mp3",
             "demuxer-mov",
+            "demuxer-wav",
             "filter-aresample",
             "filter-scale"
           ]
@@ -923,6 +925,9 @@
     },
     "demuxer-webm": {
       "description": "Enable demuxer: webm*"
+    },
+    "demuxer-wav": {
+      "description": "Enable demuxer: wav"
     },
     "filter-aresample": {
       "description": "Enable filter: aresample"

--- a/custom-ports/ffmpeg/vcpkg.json
+++ b/custom-ports/ffmpeg/vcpkg.json
@@ -823,8 +823,10 @@
             "encoder-aac",
             "decoder-aac",
             "decoder-vp9",
+            "decoder-mp3",
             "muxer-mov",
             "muxer-mp4",
+            "demuxer-mp3",
             "demuxer-mov",
             "filter-aresample",
             "filter-scale"

--- a/custom-ports/ffmpeg/vcpkg.json
+++ b/custom-ports/ffmpeg/vcpkg.json
@@ -823,15 +823,27 @@
             "encoder-aac",
             "decoder-aac",
             "decoder-vp9",
-            "decoder-mp3",
-            "decoder-pcm",
             "muxer-mov",
             "muxer-mp4",
-            "demuxer-mp3",
             "demuxer-mov",
-            "demuxer-wav",
             "filter-aresample",
             "filter-scale"
+          ]
+        }
+      ]
+    },
+    "tsc-wasm-image2video": {
+      "description": "The set of features for the image to video microapp",
+      "dependencies": [
+        {
+          "name": "ffmpeg",
+          "default-features": false,
+          "features": [
+            "tsc-wasm-base",
+            "decoder-mp3",
+            "decoder-pcm",
+            "demuxer-mp3",
+            "demuxer-wav"
           ]
         }
       ]

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -69,6 +69,16 @@
       }
     },
     {
+      "name": "ffmpeg-wasm-image2video",
+      "wasm": {
+        "package": "ffmpeg[tsc-wasm-image2video]",
+        "linkType": "dynamic",
+        "buildType": "release",
+        "customTriplet": "wasm32-emscripten-dynamic",
+        "vcpkgHash": "b2cb0da531c2f1f740045bfe7c4dac59f0b2b69c"
+      }
+    },
+    {
       "name": "ffmpeg-cloud-gpl",
       "win": {
         "package": "ffmpeg-cloud-gpl[core,avcodec,avdevice,avfilter,avformat,avresample,swscale,swresample,mp3lame,ffmpeg,ffprobe,openssl,mjpeg,png,zlib,x264,dav1d,vpx,nonfree,gpl,version3]",


### PR DESCRIPTION
Create a WASM build of Ffmpeg that supports Wav with PCM and Mp3 decoding for `luma-wasm`.