### PR TITLE
Bump build version numbers on windows ffmpeg builds

### DIFF
--- a/custom-steps/ffmpeg/version-info.json
+++ b/custom-steps/ffmpeg/version-info.json
@@ -3,7 +3,7 @@
         {
             "filename": "bin/aom.dll",
             "fileDescription": "AV1 codec library",
-            "fileVersion": "3.11.0",
+            "fileVersion": "3.11.1",
             "productName": "AV1 codec library",
             "productVersion": "3.11.0",
             "copyright": "Copyright (c) 2016, Alliance for Open Media"
@@ -11,7 +11,7 @@
         {
             "filename": "bin/avcodec-61.dll",
             "fileDescription": "FFmpeg codec library",
-            "fileVersion": "61.19.101",
+            "fileVersion": "61.19.102",
             "productName": "FFmpeg",
             "productVersion": "7.1.1",
             "copyright": "Copyright (C) 2000-2023 FFmpeg Project"
@@ -19,7 +19,7 @@
         {
             "filename": "bin/avdevice-61.dll",
             "fileDescription": "FFmpeg device handling library",
-            "fileVersion": "61.3.100.1",
+            "fileVersion": "61.3.100.2",
             "productName": "FFmpeg",
             "productVersion": "7.1.1",
             "copyright": "Copyright (C) 2000-2023 FFmpeg Project"
@@ -27,7 +27,7 @@
         {
             "filename": "bin/avfilter-10.dll",
             "fileDescription": "FFmpeg audio/video filtering library",
-            "fileVersion": "10.4.100.1",
+            "fileVersion": "10.4.100.2",
             "productName": "FFmpeg",
             "productVersion": "7.1.1",
             "copyright": "Copyright (C) 2000-2023 FFmpeg Project"
@@ -35,7 +35,7 @@
         {
             "filename": "bin/avformat-61.dll",
             "fileDescription": "FFmpeg container format library",
-            "fileVersion": "61.7.100.1",
+            "fileVersion": "61.7.100.2",
             "productName": "FFmpeg",
             "productVersion": "7.1.1",
             "copyright": "Copyright (C) 2000-2023 FFmpeg Project"
@@ -43,19 +43,23 @@
         {
             "filename": "bin/avutil-59.dll",
             "fileDescription": "FFmpeg utility library",
-            "fileVersion": "59.39.100.1",
+            "fileVersion": "59.39.100.2",
             "productName": "FFmpeg",
             "productVersion": "7.1.1",
             "copyright": "Copyright (C) 2000-2023 FFmpeg Project"
         },
         {
+            "filename": "bin/dav1d.dll",
+            "fileVersion": "7.0.0.1"
+        },
+        {
             "filename": "bin/libmp3lame.dll",
-            "fileVersion": "3.100.2.18"
+            "fileVersion": "3.100.2.19"
         },
         {
             "filename": "bin/ogg.dll",
             "fileDescription": "A library for manipulating ogg bitstreams.",
-            "fileVersion": "1.3.5.1",
+            "fileVersion": "1.3.5.2",
             "productName": "Ogg",
             "productVersion": "1.3.5.1",
             "copyright": "Copyright (c) 2002, Xiph.org Foundation"
@@ -63,15 +67,19 @@
         {
             "filename": "bin/opus.dll",
             "fileDescription": "Totally open, royalty-free, highly versatile audio codec",
-            "fileVersion": "1.5.2.1",
+            "fileVersion": "1.5.2.2",
             "productName": "Opus audio codec",
             "productVersion": "1.5.2.1",
             "copyright": "Copyright 2001-2023 Xiph.Org, Skype Limited, Octasic, Jean-Marc Valin, Timothy B. Terriberry, CSIRO, Gregory Maxwell, Mark Borgerding, Erik de Castro Lopo, Mozilla, Amazon"
         },
         {
+            "filename": "bin/SDL2.dll",
+            "fileVersion": "2.32.4.1"
+        },
+        {
             "filename": "bin/swresample-5.dll",
             "fileDescription": "FFmpeg audio resampling library",
-            "fileVersion": "5.3.100.1",
+            "fileVersion": "5.3.100.2",
             "productName": "FFmpeg",
             "productVersion": "7.1.0",
             "copyright": "Copyright (C) 2000-2023 FFmpeg Project"
@@ -79,7 +87,7 @@
         {
             "filename": "bin/swscale-8.dll",
             "fileDescription": "FFmpeg image rescaling library",
-            "fileVersion": "8.3.100.1",
+            "fileVersion": "8.3.100.2",
             "productName": "FFmpeg",
             "productVersion": "7.1.0",
             "copyright": "Copyright (C) 2000-2023 FFmpeg Project"
@@ -87,7 +95,7 @@
         {
             "filename": "bin/vorbis.dll",
             "fileDescription": "A BSD-style license software implementation of the Vorbis specification by the Xiph.Org Foundation (https://xiph.org/)",
-            "fileVersion": "1.3.7.1",
+            "fileVersion": "1.3.7.2",
             "productName": "libvorbis",
             "productVersion": "1.3.7.1",
             "copyright": "Copyright (c) 2002-2020 Xiph.org Foundation"
@@ -95,7 +103,7 @@
         {
             "filename": "bin/vorbisenc.dll",
             "fileDescription": "A BSD-style license library that provides a simple, programmatic encoding setup interface",
-            "fileVersion": "2.0.12.1",
+            "fileVersion": "2.0.12.2",
             "productName": "libvorbisenc",
             "productVersion": "2.0.12.1",
             "copyright": "Copyright (c) 2002-2020 Xiph.org Foundation"
@@ -103,14 +111,14 @@
         {
             "filename": "bin/vorbisfile.dll",
             "fileDescription": "A BSD-style license convenience library built on Vorbis designed to simplify common uses",
-            "fileVersion": "3.3.8.1",
+            "fileVersion": "3.3.8.2",
             "productName": "libvorbisfile",
             "productVersion": "3.3.8.1",
             "copyright": "Copyright (c) 2002-2020 Xiph.org Foundation"
         },
         {
             "filename": "bin/zlib1.dll",
-            "fileVersion": "1.3.1.101",
+            "fileVersion": "1.3.1.102",
             "productVersion": "1.3.1.101"
         }
     ]

--- a/custom-steps/ffmpeg/version-info.json
+++ b/custom-steps/ffmpeg/version-info.json
@@ -81,7 +81,7 @@
             "fileDescription": "FFmpeg audio resampling library",
             "fileVersion": "5.3.100.2",
             "productName": "FFmpeg",
-            "productVersion": "7.1.0",
+            "productVersion": "7.1.1",
             "copyright": "Copyright (C) 2000-2023 FFmpeg Project"
         },
         {
@@ -89,7 +89,7 @@
             "fileDescription": "FFmpeg image rescaling library",
             "fileVersion": "8.3.100.2",
             "productName": "FFmpeg",
-            "productVersion": "7.1.0",
+            "productVersion": "7.1.1",
             "copyright": "Copyright (C) 2000-2023 FFmpeg Project"
         },
         {


### PR DESCRIPTION
# Description
dav1d.dll did not have it's version updated, and is included in the CWin installer, currently.  This caused an installer test failure.  CWin's preferred solution is to just update the build number on this dll.

Since we are re-building ffmpeg to do this, I have to do the same to all other dlls, or we could end up in the same situation, with dlls that have the same version but a different hash.  I am therefore updating ALL of the fileVersions on all of these dlls, incrementing their build number by 1.  I am adding a couple other missing ones as well, for completeness.

I am also updating the productVersion on a couple of the ffmpeg dlls to 7.1.1.  It looks like that just got missed in the update to ffmpeg 7.1.1 the first time around, so I am correcting that, now.

# Testing

## 1.) Verify all tests pass for desktop builds

- [x] Create a build off the latest commit in this repo, building `[ffmpeg-desktop-base](https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_build/results?buildId=492468)`
- [x] Create a build off the latest commit in this repo, building `[ffmpeg-desktop-hevc](https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_build/results?buildId=492469&view=results)`
- [x] For each of those builds, do this:
  - [x] Click on "Build Mac" and then the "Run: install & stage (preconfigured)" step
  - [x] Search for `[      FAIL  ]` and verify you can _not_ find any instances of it in this step
  - [x] Click on "Build Windows" and then the "Run: install & stage (preconfigured)" step
  - [x] Search for `[      FAIL  ]` and verify you can _not_ find any instances of it in this step

## 2.) Verify file versions are set for Windows desktop builds

- [x] Download [check-dll-versions.ps1](https://drive.google.com/file/d/1X9LUR2GslaW4-KeKoBSd-aqrjh9iMUPU/view?usp=sharing)
- [x] Go to properties and unblock that file
- [x] Change the download link to point to the [previous ffmpeg-desktop-base build](https://github.com/TechSmith/ThirdParty-Packages-vcpkg/releases/download/ffmpeg-desktop-base-7.1.1/ffmpeg-desktop-base-windows--bin.tar.gz)
- [x] Run the script and pipe the output to `ffmpeg-desktop-base-orig.txt`
- [x] Change the download link to point to the [previous ffmpeg-desktop-hevc build](https://github.com/TechSmith/ThirdParty-Packages-vcpkg/releases/download/ffmpeg-desktop-hevc-7.1.1/ffmpeg-desktop-hevc-windows--bin.tar.gz)
- [x] Run the script and pipe the output to `ffmpeg-desktop-base-hevc-orig.txt`
- [x] Change the download link to point to the [newest ffmpeg-desktop-base build](https://github.com/TechSmith/ThirdParty-Packages-vcpkg/releases/download/ffmpeg-desktop-base-7.1.1--dll-version-fix-20250521-1257/ffmpeg-desktop-base-windows--bin.tar.gz) you built in test 1
- [x] Run the script and pipe the output to `ffmpeg-desktop-base-new.txt`
- [x] Change the download link to point to the [newest ffmpeg-desktop-hevc build](https://github.com/TechSmith/ThirdParty-Packages-vcpkg/releases/download/ffmpeg-desktop-hevc-7.1.1--dll-version-fix-20250521-1257/ffmpeg-desktop-hevc-windows--bin.tar.gz) you built in test 1
- [x] Run the script and pipe the output to `ffmpeg-desktop-base-hevc-new.txt`
- [x] Use diff tool to compare ffmpeg-desktop-base-orig.txt and ffmpeg-desktop-base-new.txt
- [x] Verify for all dlls that the fileVersion build number has increased by 1, and both swresample-5.dll and swscale-8.dll have also had their Product Version updated to 7.1.1
- [x] Use diff tool to compare ffmpeg-desktop-hevc-orig.txt and ffmpeg-desktop-hevc-new.txt
- [x] Verify for all dlls that the fileVersion build number has increased by 1, and both swresample-5.dll and swscale-8.dll have also had their Product Version updated to 7.1.1

### Related files:
- [ffmpeg-desktop-base-new.txt](https://github.com/user-attachments/files/20374949/ffmpeg-desktop-base-new.txt)
- [ffmpeg-desktop-base-orig.txt](https://github.com/user-attachments/files/20374950/ffmpeg-desktop-base-orig.txt)
- [ffmpeg-desktop-hevc-new.txt](https://github.com/user-attachments/files/20374951/ffmpeg-desktop-hevc-new.txt)
- [ffmpeg-desktop-hevc-orig.txt](https://github.com/user-attachments/files/20374952/ffmpeg-desktop-hevc-orig.txt)
