### PR TITLE
Add port: onnxruntime

### DIFF
--- a/.pipelines/build-package-preconfigured.yml
+++ b/.pipelines/build-package-preconfigured.yml
@@ -25,6 +25,7 @@ parameters:
   - libzip-static
   - libzip-dynamic
   - minizip
+  - onnxruntime
   - openblas
   - openssl-static
   - opencv4

--- a/custom-ports/onnxruntime/1000-tsc-accept-python-path.patch
+++ b/custom-ports/onnxruntime/1000-tsc-accept-python-path.patch
@@ -1,0 +1,23 @@
+diff --git a/build.bat b/build.bat
+index d0c6cbcddd..0e6ea54eb2 100644
+--- a/build.bat
++++ b/build.bat
+@@ -6,5 +6,16 @@
+ setlocal
+ set PATH=C:\Program Files\Git\usr\bin;%PATH%
+ 
+-rem Requires a Python install to be available in your PATH
+-python "%~dp0\tools\ci_build\build.py" --build_dir "%~dp0\build\Windows" %*
++rem Accepts the path to the Python executable as the first argument
++set PYTHON_EXE=%~1
++shift
++
++set REMAINING_ARGS=
++:ArgLoop
++if "%~1"=="" goto EndArgLoop
++set REMAINING_ARGS=%REMAINING_ARGS% %1
++shift
++goto ArgLoop
++:EndArgLoop
++
++"%PYTHON_EXE%" "%~dp0\tools\ci_build\build.py" --build_dir "%~dp0\build\Windows" %REMAINING_ARGS%

--- a/custom-ports/onnxruntime/1001-tsc-eigen-sha.patch
+++ b/custom-ports/onnxruntime/1001-tsc-eigen-sha.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/deps.txt b/cmake/deps.txt
+index a10bede254..5f4e8f31fa 100644
+--- a/cmake/deps.txt
++++ b/cmake/deps.txt
+@@ -22,7 +22,7 @@ dlpack;https://github.com/dmlc/dlpack/archive/refs/tags/v0.6.zip;4d565dd2e5b3132
+ # it contains changes on top of 3.4.0 which are required to fix build issues.
+ # Until the 3.4.1 release this is the best option we have.
+ # Issue link: https://gitlab.com/libeigen/eigen/-/issues/2744
+-eigen;https://gitlab.com/libeigen/eigen/-/archive/1d8b82b0740839c0de7f1242a3585e3390ff5f33/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip;5ea4d05e62d7f954a46b3213f9b2535bdd866803
++eigen;https://gitlab.com/libeigen/eigen/-/archive/1d8b82b0740839c0de7f1242a3585e3390ff5f33/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip;51982be81bbe52572b54180454df11a3ece9a934
+ flatbuffers;https://github.com/google/flatbuffers/archive/refs/tags/v23.5.26.zip;59422c3b5e573dd192fead2834d25951f1c1670c
+ fp16;https://github.com/Maratyszcza/FP16/archive/0a92994d729ff76a58f692d3028ca1b64b145d91.zip;b985f6985a05a1c03ff1bb71190f66d8f98a1494
+ fxdiv;https://github.com/Maratyszcza/FXdiv/archive/63058eff77e11aa15bf531df5dd34395ec3017c8.zip;a5658f4036402dbca7cebee32be57fb8149811e1

--- a/custom-ports/onnxruntime/1002-tsc-accept-python-path-unix.patch
+++ b/custom-ports/onnxruntime/1002-tsc-accept-python-path-unix.patch
@@ -1,0 +1,21 @@
+diff --git a/build.sh b/build.sh
+index 00000000..11111111 100755
+--- a/build.sh
++++ b/build.sh
+@@ -1,6 +1,17 @@
+ #!/bin/bash
+ set -e -o -x
+ 
+-# Requires a Python install to be available in your PATH
++# Accept the path to Python executable as first argument if provided
++if [ -n "$1" ] && [ -x "$1" ]; then
++    PYTHON_EXE="$1"
++    shift
++else
++    PYTHON_EXE="python3"
++fi
++
++# All arguments are passed to build.py
+ SOURCE_ROOT=$(realpath $(dirname $0))
+-python3 $SOURCE_ROOT/tools/ci_build/build.py "$@"
++"$PYTHON_EXE" "$SOURCE_ROOT/tools/ci_build/build.py" "$@"

--- a/custom-ports/onnxruntime/portfile.cmake
+++ b/custom-ports/onnxruntime/portfile.cmake
@@ -1,0 +1,116 @@
+# onnxruntime
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO microsoft/onnxruntime
+    REF "v${VERSION}"
+    SHA512 32310215a3646c64ff5e0a309c3049dbe02ae9dd5bda8c89796bd9f86374d0f43443aed756b941d9af20ef1758bb465981ac517bbe8ac33661a292d81c59b152
+    HEAD_REF main
+    PATCHES
+        "1000-tsc-accept-python-path.patch"
+)
+
+# --- Find Python (Host Dependency) ---
+vcpkg_find_acquire_program(PYTHON3)
+message(STATUS "Using Python3 from: ${PYTHON3}")
+
+
+# --- Check for enabled features ---
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        "build-parallel"                ENABLE_PARALLEL
+        "ep-dml"                        ENABLE_DML
+        "ep-cuda"                       ENABLE_CUDA
+        "ep-openvino"                   ENABLE_OPENVINO
+        "ep-coreml"                     ENABLE_COREML
+        "ep-tensorrt"                   ENABLE_TENSORRT
+        "compile-no-warning-as-error"   ENABLE_COMPILE_NO_WARNING_AS_ERROR
+        "skip-submodule-sync"           ENABLE_SKIP_SUBMODULE_SYNC
+        "skip-tests"                    ENABLE_SKIP_TESTS
+)
+
+# --- Assemble Build Arguments for build.py ---
+set(ONNXRUNTIME_BUILD_ARGS)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    list(APPEND ONNXRUNTIME_BUILD_ARGS --build_static_lib)
+else()
+    list(APPEND ONNXRUNTIME_BUILD_ARGS --build_shared_lib)
+endif()
+
+if(ENABLE_PARALLEL)
+    list(APPEND ONNXRUNTIME_BUILD_ARGS --parallel)
+endif()
+if(ENABLE_DML)
+    list(APPEND ONNXRUNTIME_BUILD_ARGS --use_dml)
+endif()
+if(ENABLE_CUDA)
+    list(APPEND ONNXRUNTIME_BUILD_ARGS --use_cuda)
+endif()
+if(ENABLE_OPENVINO)
+    list(APPEND ONNXRUNTIME_BUILD_ARGS --use_openvino)
+endif()
+if(ENABLE_COREML)
+    list(APPEND ONNXRUNTIME_BUILD_ARGS --use_coreml)
+endif()
+if(ENABLE_TENSORRT)
+    list(APPEND ONNXRUNTIME_BUILD_ARGS --use_tensorrt)
+endif()
+if(ENABLE_COMPILE_NO_WARNING_AS_ERROR)
+    list(APPEND ONNXRUNTIME_BUILD_ARGS --compile_no_warning_as_error)
+endif()
+if(ENABLE_SKIP_SUBMODULE_SYNC)
+    list(APPEND ONNXRUNTIME_BUILD_ARGS --skip_submodule_sync)
+else()
+    list(APPEND ONNXRUNTIME_BUILD_ARGS --update)
+endif()
+if(ENABLE_SKIP_TESTS)
+    list(APPEND ONNXRUNTIME_BUILD_ARGS --skip_tests)
+endif()
+
+# Add macOS Universal Architecture if applicable
+if(VCPKG_TARGET_IS_OSX)
+    string(APPEND CMAKE_EXTRA_DEFINES_STRING " CMAKE_OSX_ARCHITECTURES=x86_64;arm64")
+endif()
+
+# --- Add required general arguments for build.py ---
+#list(APPEND ONNXRUNTIME_BUILD_ARGS --build)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(ONNXRUNTIME_CONFIG Debug)
+else()
+    set(ONNXRUNTIME_CONFIG RelWithDebInfo)
+endif()
+list(APPEND ONNXRUNTIME_BUILD_ARGS --config ${ONNXRUNTIME_CONFIG})
+
+# # Define the build directory WITHOUT the config suffix. The script adds it.
+# set(ONNXRUNTIME_BUILD_DIR_PATH "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}")
+
+# # Clean the directory to prevent stale cache issues
+# file(REMOVE_RECURSE "${ONNXRUNTIME_BUILD_DIR_PATH}")
+# list(APPEND ONNXRUNTIME_BUILD_ARGS --build_dir "${ONNXRUNTIME_BUILD_DIR_PATH}")
+
+# --- Execute Build ---
+set(BUILD_SCRIPT_PATH "${SOURCE_PATH}/build.bat")
+message(STATUS ">>> ONNXRuntime build.bat arguments: ${ONNXRUNTIME_BUILD_ARGS}")
+
+message(STATUS ">>> SOURCE PATH: ${SOURCE_PATH}")
+
+vcpkg_execute_build_process(
+    COMMAND "${BUILD_SCRIPT_PATH}" "${PYTHON3}" ${ONNXRUNTIME_BUILD_ARGS}
+    WORKING_DIRECTORY "${SOURCE_PATH}"
+    LOGNAME "build-${TARGET_TRIPLET}-${ONNXRUNTIME_CONFIG}"
+)
+
+# # --- Post-Build Processing ---
+# vcpkg_copy_pdbs()
+# vcpkg_cmake_config_fixup(PACKAGE_NAME onnxruntime CONFIG_PATH "lib/cmake/onnxruntime")
+# vcpkg_fixup_pkgconfig()
+# file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
+# vcpkg_install_copyright(FILE_PATH "${SOURCE_PATH}/LICENSE")
+# file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage"
+#     "To use onnxruntime in your CMake project, add the following to your CMakeLists.txt:\n"
+#     "    find_package(onnxruntime CONFIG REQUIRED)\n"
+#     "    target_link_libraries(your_target PRIVATE onnxruntime::onnxruntime)\n"
+# )
+
+# message(STATUS "onnxruntime build and installation complete.")

--- a/custom-ports/onnxruntime/portfile.cmake
+++ b/custom-ports/onnxruntime/portfile.cmake
@@ -7,6 +7,8 @@ vcpkg_from_github(
     HEAD_REF main
     PATCHES
         "1000-tsc-accept-python-path.patch"
+        "1001-tsc-eigen-sha.patch"
+        "1002-tsc-accept-python-path-unix.patch"
 )
 
 # --- Find Python (Host Dependency) ---
@@ -31,7 +33,21 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 # --- Assemble Build Arguments for build.py ---
 set(ONNXRUNTIME_BUILD_ARGS)
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+# Platform-specific configurations
+if(VCPKG_TARGET_IS_EMSCRIPTEN)
+    # WASM-specific build arguments
+    list(APPEND ONNXRUNTIME_BUILD_ARGS 
+        --build_wasm
+        --skip_submodule_sync
+        --disable_wasm_exception_catching
+        --disable_rtti
+    )
+    # Always build shared for WASM
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+        message(WARNING "Static linking not recommended for WASM, using dynamic")
+    endif()
+    list(APPEND ONNXRUNTIME_BUILD_ARGS --build_shared_lib)
+elseif(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     list(APPEND ONNXRUNTIME_BUILD_ARGS --build_static_lib)
 else()
     list(APPEND ONNXRUNTIME_BUILD_ARGS --build_shared_lib)
@@ -72,6 +88,16 @@ if(VCPKG_TARGET_IS_OSX)
     string(APPEND CMAKE_EXTRA_DEFINES_STRING " CMAKE_OSX_ARCHITECTURES=x86_64;arm64")
 endif()
 
+# Add WASM-specific CMake defines
+if(VCPKG_TARGET_IS_EMSCRIPTEN)
+    list(APPEND ONNXRUNTIME_BUILD_ARGS 
+        --cmake_extra_defines
+        CMAKE_TOOLCHAIN_FILE=${VCPKG_CHAINLOAD_TOOLCHAIN_FILE}
+        onnxruntime_ENABLE_WEBASSEMBLY_SIMD=ON
+        onnxruntime_ENABLE_WEBASSEMBLY_THREADS=ON
+    )
+endif()
+
 # --- Add required general arguments for build.py ---
 #list(APPEND ONNXRUNTIME_BUILD_ARGS --build)
 
@@ -90,16 +116,28 @@ list(APPEND ONNXRUNTIME_BUILD_ARGS --config ${ONNXRUNTIME_CONFIG})
 # list(APPEND ONNXRUNTIME_BUILD_ARGS --build_dir "${ONNXRUNTIME_BUILD_DIR_PATH}")
 
 # --- Execute Build ---
-set(BUILD_SCRIPT_PATH "${SOURCE_PATH}/build.bat")
-message(STATUS ">>> ONNXRuntime build.bat arguments: ${ONNXRUNTIME_BUILD_ARGS}")
-
-message(STATUS ">>> SOURCE PATH: ${SOURCE_PATH}")
-
-vcpkg_execute_build_process(
-    COMMAND "${BUILD_SCRIPT_PATH}" "${PYTHON3}" ${ONNXRUNTIME_BUILD_ARGS}
-    WORKING_DIRECTORY "${SOURCE_PATH}"
-    LOGNAME "build-${TARGET_TRIPLET}-${ONNXRUNTIME_CONFIG}"
-)
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_EMSCRIPTEN)
+    set(BUILD_SCRIPT_PATH "${SOURCE_PATH}/build.bat")
+    message(STATUS ">>> ONNXRuntime build.bat arguments: ${ONNXRUNTIME_BUILD_ARGS}")
+    message(STATUS ">>> SOURCE PATH: ${SOURCE_PATH}")
+    
+    vcpkg_execute_build_process(
+        COMMAND "${BUILD_SCRIPT_PATH}" "${PYTHON3}" ${ONNXRUNTIME_BUILD_ARGS}
+        WORKING_DIRECTORY "${SOURCE_PATH}"
+        LOGNAME "build-${TARGET_TRIPLET}-${ONNXRUNTIME_CONFIG}"
+    )
+else()
+    # Use build.sh for Unix-like systems (macOS, Linux, WASM)
+    set(BUILD_SCRIPT_PATH "${SOURCE_PATH}/build.sh")
+    message(STATUS ">>> ONNXRuntime build.sh arguments: ${PYTHON3} ${ONNXRUNTIME_BUILD_ARGS}")
+    message(STATUS ">>> SOURCE PATH: ${SOURCE_PATH}")
+    
+    vcpkg_execute_build_process(
+        COMMAND ${BUILD_SCRIPT_PATH} ${PYTHON3} ${ONNXRUNTIME_BUILD_ARGS}
+        WORKING_DIRECTORY "${SOURCE_PATH}"
+        LOGNAME "build-${TARGET_TRIPLET}-${ONNXRUNTIME_CONFIG}"
+    )
+endif()
 
 # # --- Post-Build Processing ---
 # vcpkg_copy_pdbs()

--- a/custom-ports/onnxruntime/vcpkg.json
+++ b/custom-ports/onnxruntime/vcpkg.json
@@ -1,0 +1,64 @@
+{
+  "name": "onnxruntime",
+  "version": "1.22.0",
+  "port-version": 1,
+  "description": "A cross-platform inference and training machine-learning accelerator",
+  "homepage": "https://github.com/microsoft/onnxruntime",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "python3",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "build-parallel",
+    "compile-no-warning-as-error",
+    "skip-submodule-sync",
+    "skip-tests",
+    {
+      "name": "ep-dml",
+      "platform": "windows"
+    },
+    {
+      "name": "ep-coreml",
+      "platform": "osx"
+    }
+  ],
+  "features": {
+    "build-parallel": {
+      "description": "Enable parallel builds for faster compilation. Maps to the --parallel flag."
+    },
+    "compile-no-warning-as-error": {
+      "description": "Do not treat compiler warnings as errors. Maps to the --compile_no_warning_as_error flag."
+    },
+    "ep-coreml": {
+      "description": "Enable the CoreML execution provider on Apple platforms. Maps to the --use_coreml flag."
+    },
+    "ep-cuda": {
+      "description": "Enable the CUDA execution provider. Requires CUDA toolkit. Maps to the --use_cuda flag."
+    },
+    "ep-dml": {
+      "description": "Enable the DirectML execution provider on Windows. Maps to the --use_dml flag."
+    },
+    "ep-openvino": {
+      "description": "Enable the OpenVINO execution provider. Requires OpenVINO toolkit. Maps to the --use_openvino flag."
+    },
+    "ep-tensorrt": {
+      "description": "Enable the TensorRT execution provider. Requires TensorRT. Maps to the --use_tensorrt flag."
+    },
+    "skip-submodule-sync": {
+      "description": "Skip synchronizing/updating Git submodules. Maps to the --skip_submodule_sync flag."
+    },
+    "skip-tests": {
+      "description": "Skip running tests after the build. Maps to the --skip_tests flag."
+    }
+  }
+}

--- a/custom-ports/onnxruntime/vcpkg.json
+++ b/custom-ports/onnxruntime/vcpkg.json
@@ -25,7 +25,7 @@
     "skip-tests",
     {
       "name": "ep-dml",
-      "platform": "windows"
+      "platform": "windows & !emscripten"
     },
     {
       "name": "ep-coreml",

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -407,6 +407,12 @@
         "package": "onnxruntime",
         "linkType": "dynamic",
         "buildType": "release"
+      },
+      "wasm": {
+        "package": "onnxruntime[build-parallel,compile-no-warning-as-error,skip-submodule-sync,skip-tests]",
+        "linkType": "dynamic",
+        "buildType": "release",
+        "customTriplet": "wasm32-emscripten-dynamic"
       }
     },
     {

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -395,6 +395,32 @@
           "tools": true
         }
       }
+    },
+    {
+      "name": "onnxruntime",
+      "mac": {
+        "package": "onnxruntime",
+        "linkType": "dynamic",
+        "buildType": "release"
+      },
+      "win": {
+        "package": "onnxruntime",
+        "linkType": "dynamic",
+        "buildType": "release"
+      }
+    },
+    {
+      "name": "directml",
+      "mac": {
+        "package": "directml",
+        "linkType": "dynamic",
+        "buildType": "release"
+      },
+      "win": {
+        "package": "directml",
+        "linkType": "dynamic",
+        "buildType": "release"
+      }
     }
   ]
 }


### PR DESCRIPTION
# Description
This adds a port for onnxruntime.  I implemented this as a thin wrapper over the python script instead of doing this in a more traditional way, as this whole repo really seems to want to use this python script to build it.