### PR TITLE
Kaldi port uses updated openfst with Xcode 16.4 build fix

### DIFF
--- a/custom-ports/kaldi/00001-fix-build.patch
+++ b/custom-ports/kaldi/00001-fix-build.patch
@@ -1,0 +1,16 @@
+diff --git a/cmake/third_party/openfst.cmake b/cmake/third_party/openfst.cmake
+index f9fff8a54..4bdaa3da0 100644
+--- a/cmake/third_party/openfst.cmake
++++ b/cmake/third_party/openfst.cmake
+@@ -3,8 +3,8 @@ include(FetchContent)
+
+ FetchContent_Declare(
+         openfst
+-        GIT_REPOSITORY  https://github.com/kkm000/openfst
+-        GIT_TAG         338225416178ac36b8002d70387f5556e44c8d05 # tag win/1.7.2.1
++        GIT_REPOSITORY  https://github.com/TechSmith/openfst.git
++        GIT_TAG         56899e1f22ee91e7adfd55c5173bb0630bd2d131 # includes compilation fix for VectorHashBiTable
+ )
+
+ FetchContent_GetProperties(openfst)
+

--- a/custom-ports/kaldi/portfile.cmake
+++ b/custom-ports/kaldi/portfile.cmake
@@ -3,6 +3,8 @@ vcpkg_from_git(
    URL https://github.com/kaldi-asr/kaldi.git
    REF 4a8b7f673275597fef8a15b160124bd0985b59bd # latest as of October 4th
    HEAD_REF main
+   PATCHES
+      00001-fix-build.patch
 )
 # Set this so it doesn't try and use git to find the version
 # This is what get_version() inside of the kaldi CMakelists.txt calculated


### PR DESCRIPTION
Forked https://github.com/TechSmith/openfst and applied the build fix there. We now pull that fork into our Kaldi build.