### PR TITLE
+replxx

### DIFF
--- a/.pipelines/build-package-preconfigured.yml
+++ b/.pipelines/build-package-preconfigured.yml
@@ -29,6 +29,7 @@ parameters:
   - openssl-static
   - opencv4
   - pango-desktop
+  - replxx
   - sqlite3
   - sqlite-modern-cpp
   - tinyxml

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -405,8 +405,7 @@
       },
       "win": {
         "package": "replxx",
-        "linkType": "static",
-        "buildType": "release"
+        "customTriplet": "x64-windows-static-md"
       }
     }
   ]

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -405,7 +405,10 @@
       },
       "win": {
         "package": "replxx",
-        "customTriplet": "x64-windows-static-md"
+        "customTriplet": "x64-windows-static-md",
+        "publish": {
+          "debug": true
+        }
       }
     }
   ]

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -395,6 +395,19 @@
           "tools": true
         }
       }
+    },
+    {
+      "name": "replxx",
+      "mac": {
+        "package": "replxx",
+        "linkType": "static",
+        "buildType": "release"
+      },
+      "win": {
+        "package": "replxx",
+        "linkType": "static",
+        "buildType": "release"
+      }
     }
   ]
 }


### PR DESCRIPTION
[replxx](https://github.com/AmokHuginnsson/replxx) - BSD licensed

> A small, portable GNU readline replacement for Linux, Windows and MacOS which is capable of handling UTF-8 characters. Unlike GNU readline, which is GPL, this library uses a BSD license and can be used in any kind of program.

We can use this to implement REPL command line tools