### PR TITLE
Consolidate ffmpeg-wasm builds into one

### DIFF
--- a/.pipelines/build-package-preconfigured.yml
+++ b/.pipelines/build-package-preconfigured.yml
@@ -15,8 +15,7 @@ parameters:
   - ffmpeg-cloud-gpl
   - ffmpeg-desktop-base
   - ffmpeg-desktop-hevc
-  - ffmpeg-wasm-base
-  - ffmpeg-wasm-image2video
+  - ffmpeg-wasm
   - glslang
   - hunspell
   - hunspell-debug

--- a/custom-ports/ffmpeg/vcpkg.json
+++ b/custom-ports/ffmpeg/vcpkg.json
@@ -864,9 +864,13 @@
             "decoder-aac-latm",
             "decoder-vp9",
             "decoder-libopus",
+            "decoder-mp3-all",
+            "decoder-pcm-all",
             "encoder-aac",
             "encoder-libopus",
             "demuxer-mov",
+            "demuxer-mp3",
+            "demuxer-wav",
             "muxer-mov",
             "muxer-mp4",
             "parser-aac",
@@ -874,22 +878,6 @@
             "parser-opus",
             "filter-aresample",
             "filter-scale"
-          ]
-        }
-      ]
-    },
-    "tsc-wasm-image2video": {
-      "description": "The set of features for the image to video microapp",
-      "dependencies": [
-        {
-          "name": "ffmpeg",
-          "default-features": false,
-          "features": [
-            "tsc-wasm-base",
-            "decoder-mp3-all",
-            "decoder-pcm-all",
-            "demuxer-mp3",
-            "demuxer-wav"
           ]
         }
       ]
@@ -2621,6 +2609,6 @@
     "filter-aresample": { "description": "" },
     "filter-asetrate": { "description": "" },
     "filter-atempo": { "description": "" },
-    "filter-scale": { "description": "" }   
+    "filter-scale": { "description": "" }
   }
 }

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -59,19 +59,9 @@
       }
     },
     {
-      "name": "ffmpeg-wasm-base",
+      "name": "ffmpeg-wasm",
       "wasm": {
         "package": "ffmpeg[tsc-wasm-base]",
-        "linkType": "dynamic",
-        "buildType": "release",
-        "customTriplet": "wasm32-emscripten-dynamic",
-        "vcpkgHash": "2025.04.09"
-      }
-    },
-    {
-      "name": "ffmpeg-wasm-image2video",
-      "wasm": {
-        "package": "ffmpeg[tsc-wasm-image2video]",
         "linkType": "dynamic",
         "buildType": "release",
         "customTriplet": "wasm32-emscripten-dynamic",


### PR DESCRIPTION
We now want a normal FFmpeg build that contains WAV and MP3 decoding.

To simplify everything, I decided to just consolidate our ffmpeg-wasm builds into one build that has everything.

We can always split out another custom version later if needed, but I don't foresee any need to right now.