### PR TITLE
Update/pango for expat2.7.2

### DIFF
--- a/custom-ports/glib/libintl.patch
+++ b/custom-ports/glib/libintl.patch
@@ -1,11 +1,10 @@
 diff --git a/meson.build b/meson.build
+index 5677fa8..6407c64 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -2134,10 +2135,10 @@ libz_dep = dependency('zlib')
- # proxy-libintl subproject.
- # FIXME: glib-gettext.m4 has much more checks to detect broken/uncompatible
+@@ -2307,8 +2307,9 @@ endif
  # implementations. This could be extended if issues are found in some platforms.
--libintl_deps = []
+ libintl_deps = []
  libintl_prefix = '#include <libintl.h>'
 -libintl = dependency('intl', required: false)
 -if libintl.found() and libintl.type_name() != 'internal'

--- a/custom-ports/glib/portfile.cmake
+++ b/custom-ports/glib/portfile.cmake
@@ -1,9 +1,16 @@
-# vcpkg_from_* is not used because the project uses submodules.
-string(REGEX MATCH "^([0-9]*[.][0-9]*)" GLIB_MAJOR_MINOR "${VERSION}")
+string(REGEX MATCH "^([0-9]*[.][0-9]*)" VERSION_MAJOR_MINOR "${VERSION}")
+# https://github.com/GNOME/glib/blob/main/SECURITY.md#supported-versions
+if(NOT VERSION_MAJOR_MINOR MATCHES "[02468]\$")
+    message("${Z_VCPKG_BACKCOMPAT_MESSAGE_LEVEL}" "glib ${VERSION_MAJOR_MINOR} is a not a \"stable release series\".")
+endif()
+# vcpkg_from_* is not used because the project uses submodules and Anubis deployed to GNOME's gitlab
+# causes vcpkg_from_gitlab to fail for several users
 vcpkg_download_distfile(GLIB_ARCHIVE
-    URLS "https://download.gnome.org/sources/glib/${GLIB_MAJOR_MINOR}/glib-${VERSION}.tar.xz"
-    FILENAME "glib-${VERSION}.tar.xz"
-    SHA512 39e1ade8ba5a43e6dbd4c60b48327a87d50755be96eddfffce824bd5d417f6d3a9b80e6b307b47c3a74d52e726954f7c38e3245f87f32ef4dccb3f0a51eabc1e
+    URLS
+        "https://download.gnome.org/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
+        "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
+    FILENAME "${PORT}-${VERSION}.tar.xz"
+    SHA512 2b53aba22eef2d21cb40334fe55715bf0ca5009e5e105c462cdedfb45da96cca35e7edc95af27022893832feb5bfc0b0ee554382c8c8f55a2a777b864cfc53ba
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH
@@ -20,7 +27,7 @@ if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
 endif()
 
 vcpkg_list(SET OPTIONS)
-if (selinux IN_LIST FEATURES)
+if ("selinux" IN_LIST FEATURES)
     if(NOT EXISTS "/usr/include/selinux")
         message(WARNING "SELinux was not found in its typical system location. Your build may fail. You can install SELinux with \"apt-get install selinux libselinux1-dev\".")
     endif()
@@ -29,7 +36,7 @@ else()
     list(APPEND OPTIONS -Dselinux=disabled)
 endif()
 
-if (libmount IN_LIST FEATURES)
+if ("libmount" IN_LIST FEATURES)
     list(APPEND OPTIONS -Dlibmount=enabled)
 else()
     list(APPEND OPTIONS -Dlibmount=disabled)
@@ -50,10 +57,12 @@ vcpkg_configure_meson(
     OPTIONS
         ${OPTIONS}
         -Ddocumentation=false
+        -Ddtrace=disabled
         -Dinstalled_tests=false
         -Dintrospection=disabled
         -Dlibelf=disabled
         -Dman-pages=disabled
+        -Dsysprof=disabled
         -Dtests=false
         -Dxattr=false
 )

--- a/custom-ports/glib/use-libiconv-on-windows.patch
+++ b/custom-ports/glib/use-libiconv-on-windows.patch
@@ -1,5 +1,5 @@
 diff --git a/glib/gconvert.c b/glib/gconvert.c
-index 829fe38de..e01ad8884 100644
+index 53b2065..3e29bee 100644
 --- a/glib/gconvert.c
 +++ b/glib/gconvert.c
 @@ -33,7 +33,8 @@
@@ -13,10 +13,10 @@ index 829fe38de..e01ad8884 100644
  
  #include "gconvert.h"
 diff --git a/meson.build b/meson.build
-index d465253af..34ce69e4d 100644
+index f30ca58..5677fa8 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -2038,7 +2038,8 @@ glibconfig_conf.set10('G_HAVE_GROWING_STACK', growing_stack)
+@@ -2233,7 +2233,8 @@ glibconfig_conf.set10('G_HAVE_GROWING_STACK', growing_stack)
  if host_system == 'windows'
    # We have a #include "win_iconv.c" in gconvert.c on Windows, so we don't need
    # any external library for it

--- a/custom-ports/glib/vcpkg.json
+++ b/custom-ports/glib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glib",
-  "version": "2.83.4",
+  "version": "2.86.3",
   "description": "Portable, general-purpose utility library.",
   "homepage": "https://developer.gnome.org/glib/",
   "license": "LGPL-2.1-or-later",

--- a/custom-steps/pango/version-info.json
+++ b/custom-steps/pango/version-info.json
@@ -4,25 +4,25 @@
     {
       "filename": "bin/brotlicommon.dll",
       "fileDescription": "Brotli common dictionary library",
-      "fileVersion": "1.1.0",
+      "fileVersion": "1.2.0",
       "productName": "Brotli",
-      "productVersion": "1.1.0",
+      "productVersion": "1.2.0",
       "copyright": "Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors."
     },
     {
       "filename": "bin/brotlidec.dll",
       "fileDescription": "Brotli decoder library",
-      "fileVersion": "1.1.0",
+      "fileVersion": "1.2.0",
       "productName": "Brotli",
-      "productVersion": "1.1.0",
+      "productVersion": "1.2.0",
       "copyright": "Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors."
     },
     {
       "filename": "bin/brotlienc.dll",
       "fileDescription": "Brotli encoder library",
-      "fileVersion": "1.1.0",
+      "fileVersion": "1.2.0",
       "productName": "Brotli",
-      "productVersion": "1.1.0",
+      "productVersion": "1.2.0",
       "copyright": "Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors."
     },
     {
@@ -60,7 +60,7 @@
     {
       "filename": "bin/charset-1.dll",
       "fileDescription": "libcharset",
-      "fileVersion": "1.5.0",
+      "fileVersion": "1.18",
       "productName": "libiconv: character set conversion library",
       "productVersion": "1.18",
       "copyright": "Copyright (C) 1999-2022"
@@ -68,17 +68,17 @@
     {
       "filename": "bin/ffi-8.dll",
       "fileDescription": "libffi",
-      "fileVersion": "3.5.1",
+      "fileVersion": "3.5.2",
       "productName": "libffi: The portable foreign function interface library",
-      "productVersion": "3.5.1",
+      "productVersion": "3.5.2",
       "copyright": "Copyright (c) 1996-2024  Anthony Green, Red Hat, Inc and others."
     },
     {
       "filename": "bin/fontconfig-1.dll",
       "fileDescription": "Fontconfig",
-      "fileVersion": "2.15.0",
+      "fileVersion": "2.17.1",
       "productName": "Font configuration and customization library",
-      "productVersion": "2.15.0",
+      "productVersion": "2.17.1",
       "copyright": "Copyright (c) 2000-2020 Keith Packard, Patrick Lam and others"
     },
     {
@@ -100,49 +100,49 @@
     {
       "filename": "bin/gio-2.0-0.dll",
       "fileDescription": "Gio",
-      "fileVersion": "2.84.2",
+      "fileVersion": "2.86.3",
       "productName": "GLib",
-      "productVersion": "2.84.2",
+      "productVersion": "2.86.3",
       "copyright": "Copyright 2006-2011 Red Hat, Inc. and others."
     },
     {
       "filename": "bin/girepository-2.0-0.dll",
       "fileDescription": "GObject Introspection repository parser",
-      "fileVersion": "2.84.2",
+      "fileVersion": "2.86.3",
       "productName": "GLib",
-      "productVersion": "2.84.2",
+      "productVersion": "2.86.3",
       "copyright": "Copyright (C) 2005-2025 Matthias Clasen, Red Hat, Inc. and others"
     },
     {
       "filename": "bin/glib-2.0-0.dll",
       "fileDescription": "GLib",
-      "fileVersion": "2.84.2",
+      "fileVersion": "2.86.3",
       "productName": "GLib",
-      "productVersion": "2.84.2",
+      "productVersion": "2.86.3",
       "copyright": "Copyright 1995-2011 Peter Mattis, Spencer Kimball, Josh MacDonald and others."
     },
     {
       "filename": "bin/gmodule-2.0-0.dll",
       "fileDescription": "GModule",
-      "fileVersion": "2.84.2",
+      "fileVersion": "2.86.3",
       "productName": "GLib",
-      "productVersion": "22.84.2",
+      "productVersion": "22.86.3",
       "copyright": "Copyright 1998-2011 Tim Janik and others."
     },
     {
       "filename": "bin/gobject-2.0-0.dll",
       "fileDescription": "GObject",
-      "fileVersion": "2.84.2",
+      "fileVersion": "2.86.3",
       "productName": "GLib",
-      "productVersion": "2.84.2",
+      "productVersion": "2.86.3",
       "copyright": "Copyright 1998-2011 Tim Janik, Red Hat, Inc. and others"
     },
     {
       "filename": "bin/gthread-2.0-0.dll",
       "fileDescription": "GThread",
-      "fileVersion": "2.84.2",
+      "fileVersion": "2.86.3",
       "productName": "GLib",
-      "productVersion": "2.84.2",
+      "productVersion": "2.86.3",
       "copyright": "Copyright 1995-2011 Peter Mattis, Spencer Kimball, Josh MacDonald, Sebastian Wilhelmi and others."
     },
     {
@@ -156,9 +156,9 @@
     {
       "filename": "bin/harfbuzz.dll",
       "fileDescription": "HarfBuzz text shaping library",
-      "fileVersion": "10.2.0",
+      "fileVersion": "10.3.0",
       "productName": "Harfbuzz",
-      "productVersion": "10.2.0",
+      "productVersion": "10.3.0",
       "copyright": "Copyright © 2010-2022 Google, Inc. and others"
     },
     {
@@ -180,81 +180,81 @@
     {
       "filename": "bin/libexpat.dll",
       "fileDescription": "Expat XML parser",
-      "fileVersion": "2.7.1",
+      "fileVersion": "2.7.3",
       "productName": "Expat",
-      "productVersion": "2.7.1",
+      "productVersion": "2.7.3",
       "copyright": "Copyright (c) 2001-2022 Expat maintainers"
     },
     {
       "filename": "bin/libpng16.dll",
       "fileDescription": "Loads and saves PNG files",
-      "fileVersion": "1.6.47",
+      "fileVersion": "1.6.53",
       "productName": "libpng",
-      "productVersion": "1.6.47",
+      "productVersion": "1.6.53",
       "copyright": "Copyright (c) 1995-2025 The PNG Reference Library Authors."
     },
     {
       "filename": "bin/pango-1.0-0.dll",
       "fileDescription": "Pango",
-      "fileVersion": "1.56.1",
+      "fileVersion": "1.57.0",
       "productName": "Pango",
-      "productVersion": "1.56.1",
+      "productVersion": "1.57.0",
       "copyright": "Copyright 1999 Red Hat Software."
     },
     {
       "filename": "bin/pangocairo-1.0-0.dll",
       "fileDescription": "PangoCairo",
-      "fileVersion": "1.56.1",
+      "fileVersion": "1.57.0",
       "productName": "PangoCairo",
-      "productVersion": "1.56.1",
+      "productVersion": "1.57.0",
       "copyright": "Copyright 2010 Red Hat Software."
     },
     {
       "filename": "bin/pangoft2-1.0-0.dll",
       "fileDescription": "PangoFT2",
-      "fileVersion": "1.56.1",
+      "fileVersion": "1.57.0",
       "productName": "PangoFT2",
-      "productVersion": "1.56.1",
+      "productVersion": "1.57.0",
       "copyright": "Copyright 1999 Red Hat Software. Copyright 2000 Tor Lillqvist"
     },
     {
       "filename": "bin/pangowin32-1.0-0.dll",
       "fileDescription": "PangoWin32",
-      "fileVersion": "1.56.1",
+      "fileVersion": "1.57.0",
       "productName": "PangoWin32",
-      "productVersion": "1.56.1",
+      "productVersion": "1.57.0",
       "copyright": "Copyright 1999 Red Hat Software. Copyright 2000 Tor Lillqvist"
     },
     {
       "filename": "bin/pcre2-16.dll",
       "fileDescription": "PCRE2 - Perl compatible regular expressions C library (2nd API) with 16 bit character support",
-      "fileVersion": "12.0.2",
+      "fileVersion": "10.47",
       "productName": "libpcre2-16",
-      "productVersion": "12.0.2",
+      "productVersion": "10.47",
       "copyright": "Copyright (c) 1997-2024 University of Cambridge and others"
     },
     {
       "filename": "bin/pcre2-32.dll",
       "fileDescription": "PCRE2 - Perl compatible regular expressions C library (2nd API) with 32 bit character support",
-      "fileVersion": "12.0.2",
+      "fileVersion": "10.47",
       "productName": "libpcre2-32",
-      "productVersion": "12.0.2",
+      "productVersion": "10.47",
       "copyright": "Copyright (c) 1997-2024 University of Cambridge and others"
     },
     {
       "filename": "bin/pcre2-8.dll",
       "fileDescription": "PCRE2 - Perl compatible regular expressions C library (2nd API) with 8 bit character support",
-      "fileVersion": "12.0.2",
+      "fileVersion": "10.47",
       "productName": "libpcre2-8",
-      "productVersion": "12.0.2",
+      "productVersion": "10.47",
       "copyright": "Copyright (c) 1997-2024 University of Cambridge and others"
     },
     {
       "filename": "bin/pcre2-posix.dll",
       "fileDescription": "Posix compatible interface to libpcre2-8",
-      "fileVersion": "3.5.0",
+      "fileVersion": "10.47",
       "productName": "libpcre2-posix",
-      "productVersion": "3.5.0",
+      "productVersion": "10.47",
       "copyright": "Copyright (c) 1997-2024 University of Cambridge and others"
     },
     {

--- a/custom-steps/pango/version-info.json
+++ b/custom-steps/pango/version-info.json
@@ -1,5 +1,5 @@
 {
-  "buildNumber": 101,
+  "buildNumber": 102,
   "files": [
     {
       "filename": "bin/brotlicommon.dll",

--- a/custom-steps/pango/version-info.json
+++ b/custom-steps/pango/version-info.json
@@ -148,17 +148,17 @@
     {
       "filename": "bin/harfbuzz-subset.dll",
       "fileDescription": "HarfBuzz font subsetter",
-      "fileVersion": "10.2.0",
+      "fileVersion": "12.3.0",
       "productName": "Harfbuzz",
-      "productVersion": "10.2.0",
+      "productVersion": "12.3.0",
       "copyright": "Copyright © 2010-2022 Google, Inc. and others"
     },
     {
       "filename": "bin/harfbuzz.dll",
       "fileDescription": "HarfBuzz text shaping library",
-      "fileVersion": "10.3.0",
+      "fileVersion": "12.3.0",
       "productName": "Harfbuzz",
-      "productVersion": "10.3.0",
+      "productVersion": "12.3.0",
       "copyright": "Copyright © 2010-2022 Google, Inc. and others"
     },
     {

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -161,13 +161,13 @@
         "package": "pango",
         "linkType": "dynamic",
         "buildType": "release",
-        "vcpkgHash": "2025.06.13"
+        "vcpkgHash": "2026.01.16"
       },
       "win": {
         "package": "pango",
         "linkType": "dynamic",
         "buildType": "release",
-        "vcpkgHash": "2025.06.13"
+        "vcpkgHash": "2026.01.16"
       }
     },
     {


### PR DESCRIPTION
# Description
Update pango for libexpat 2.7.2
This is needed for this SnagitWin issue:
https://github.com/TechSmith/SnagitWin/issues/29334

# Done
What I have done:
- mimic #87
- verify that glib port in vcpkg 2026.01.16 included libexpat 2.7.2
- checked out locally vcpkg: https://github.com/microsoft/vcpkg/releases/tag/2026.01.16
   - update all the versions of all the ports from this tag, into pango\version-info.json
- checkout out locally glib: https://github.com/GNOME/glib/releases/tag/2.86.3
   - verified that `tsc-allow-threadpriority-to-fail-windows.patch` still applies correctly

# Testing