### PR TITLE
Update Pango for Expat CVE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .vs/
 vcpkg/
+vcpkg2/
 PreStage/
 StagedArtifacts/
 logs/
+_temp/

--- a/custom-ports/glib/libintl.patch
+++ b/custom-ports/glib/libintl.patch
@@ -1,11 +1,10 @@
 diff --git a/meson.build b/meson.build
+index 5677fa8..6407c64 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -2134,10 +2135,10 @@ libz_dep = dependency('zlib')
- # proxy-libintl subproject.
- # FIXME: glib-gettext.m4 has much more checks to detect broken/uncompatible
+@@ -2307,8 +2307,9 @@ endif
  # implementations. This could be extended if issues are found in some platforms.
--libintl_deps = []
+ libintl_deps = []
  libintl_prefix = '#include <libintl.h>'
 -libintl = dependency('intl', required: false)
 -if libintl.found() and libintl.type_name() != 'internal'

--- a/custom-ports/glib/portfile.cmake
+++ b/custom-ports/glib/portfile.cmake
@@ -1,9 +1,16 @@
-# vcpkg_from_* is not used because the project uses submodules.
-string(REGEX MATCH "^([0-9]*[.][0-9]*)" GLIB_MAJOR_MINOR "${VERSION}")
+string(REGEX MATCH "^([0-9]*[.][0-9]*)" VERSION_MAJOR_MINOR "${VERSION}")
+# https://github.com/GNOME/glib/blob/main/SECURITY.md#supported-versions
+if(NOT VERSION_MAJOR_MINOR MATCHES "[02468]\$")
+    message("${Z_VCPKG_BACKCOMPAT_MESSAGE_LEVEL}" "glib ${VERSION_MAJOR_MINOR} is a not a \"stable release series\".")
+endif()
+# vcpkg_from_* is not used because the project uses submodules and Anubis deployed to GNOME's gitlab
+# causes vcpkg_from_gitlab to fail for several users
 vcpkg_download_distfile(GLIB_ARCHIVE
-    URLS "https://download.gnome.org/sources/glib/${GLIB_MAJOR_MINOR}/glib-${VERSION}.tar.xz"
-    FILENAME "glib-${VERSION}.tar.xz"
-    SHA512 39e1ade8ba5a43e6dbd4c60b48327a87d50755be96eddfffce824bd5d417f6d3a9b80e6b307b47c3a74d52e726954f7c38e3245f87f32ef4dccb3f0a51eabc1e
+    URLS
+        "https://download.gnome.org/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
+        "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
+    FILENAME "${PORT}-${VERSION}.tar.xz"
+    SHA512 2b53aba22eef2d21cb40334fe55715bf0ca5009e5e105c462cdedfb45da96cca35e7edc95af27022893832feb5bfc0b0ee554382c8c8f55a2a777b864cfc53ba
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH
@@ -20,7 +27,7 @@ if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
 endif()
 
 vcpkg_list(SET OPTIONS)
-if (selinux IN_LIST FEATURES)
+if ("selinux" IN_LIST FEATURES)
     if(NOT EXISTS "/usr/include/selinux")
         message(WARNING "SELinux was not found in its typical system location. Your build may fail. You can install SELinux with \"apt-get install selinux libselinux1-dev\".")
     endif()
@@ -29,7 +36,7 @@ else()
     list(APPEND OPTIONS -Dselinux=disabled)
 endif()
 
-if (libmount IN_LIST FEATURES)
+if ("libmount" IN_LIST FEATURES)
     list(APPEND OPTIONS -Dlibmount=enabled)
 else()
     list(APPEND OPTIONS -Dlibmount=disabled)
@@ -50,10 +57,12 @@ vcpkg_configure_meson(
     OPTIONS
         ${OPTIONS}
         -Ddocumentation=false
+        -Ddtrace=disabled
         -Dinstalled_tests=false
         -Dintrospection=disabled
         -Dlibelf=disabled
         -Dman-pages=disabled
+        -Dsysprof=disabled
         -Dtests=false
         -Dxattr=false
 )

--- a/custom-ports/glib/use-libiconv-on-windows.patch
+++ b/custom-ports/glib/use-libiconv-on-windows.patch
@@ -1,5 +1,5 @@
 diff --git a/glib/gconvert.c b/glib/gconvert.c
-index 829fe38de..e01ad8884 100644
+index 53b2065..3e29bee 100644
 --- a/glib/gconvert.c
 +++ b/glib/gconvert.c
 @@ -33,7 +33,8 @@
@@ -13,10 +13,10 @@ index 829fe38de..e01ad8884 100644
  
  #include "gconvert.h"
 diff --git a/meson.build b/meson.build
-index d465253af..34ce69e4d 100644
+index f30ca58..5677fa8 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -2038,7 +2038,8 @@ glibconfig_conf.set10('G_HAVE_GROWING_STACK', growing_stack)
+@@ -2233,7 +2233,8 @@ glibconfig_conf.set10('G_HAVE_GROWING_STACK', growing_stack)
  if host_system == 'windows'
    # We have a #include "win_iconv.c" in gconvert.c on Windows, so we don't need
    # any external library for it

--- a/custom-ports/glib/vcpkg.json
+++ b/custom-ports/glib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glib",
-  "version": "2.83.4",
+  "version": "2.86.3",
   "description": "Portable, general-purpose utility library.",
   "homepage": "https://developer.gnome.org/glib/",
   "license": "LGPL-2.1-or-later",

--- a/custom-steps/pango/add-objc-language-support.patch
+++ b/custom-steps/pango/add-objc-language-support.patch
@@ -1,0 +1,21 @@
+diff --git a/ports/pango/portfile.cmake b/ports/pango/portfile.cmake
+index df2cf032c9..7ca6990b7f 100644
+--- a/ports/pango/portfile.cmake
++++ b/ports/pango/portfile.cmake
+@@ -19,8 +19,16 @@ else()
+     list(APPEND OPTIONS_RELEASE -Dintrospection=disabled)
+ endif()
+ 
++# <TechSmith Customizations>
++set(LANGUAGES C CXX)
++if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
++    list(APPEND LANGUAGES OBJC OBJCXX)
++endif()
++# </TechSmith Customizations>
++
+ vcpkg_configure_meson(
+     SOURCE_PATH "${SOURCE_PATH}"
++    LANGUAGES ${LANGUAGES}
+     OPTIONS
+         -Ddocumentation=false
+         -Dman-pages=false

--- a/custom-steps/pango/post-build.ps1
+++ b/custom-steps/pango/post-build.ps1
@@ -25,11 +25,13 @@ if((Get-IsOnMacOS)) {
         
         if ($state -eq "INSTALLED") {
             Write-Message "Uninstalling setuptools (was installed by pre-build)..."
-            python3 -m pip uninstall -y setuptools
+            python3 -m pip uninstall -y setuptools 2>&1 | Out-Null
             if ($LASTEXITCODE -eq 0) {
                 Write-Message "> setuptools uninstalled successfully"
             } else {
-                Write-Message "> Warning: setuptools uninstallation failed"
+                Write-Message "> Warning: setuptools uninstallation failed (exit code: $LASTEXITCODE)"
+                # Reset exit code to prevent build failure
+                $global:LASTEXITCODE = 0
             }
         } elseif ($state -eq "PREEXISTING") {
             Write-Message "Skipping setuptools cleanup (was pre-existing)"

--- a/custom-steps/pango/post-build.ps1
+++ b/custom-steps/pango/post-build.ps1
@@ -15,3 +15,28 @@ if(-not (Get-Module -Name $moduleName)) {
 if((Get-IsOnWindowsOS)) {
     Update-VersionInfoForDlls -buildArtifactsPath $buildArtifactsPath -versionInfoJsonPath "$PSScriptRoot/version-info.json"
 }
+
+if((Get-IsOnMacOS)) {
+    # Clean up setuptools if we installed it
+    $stateFile = "$PSScriptRoot/.setuptools-state.txt"
+    if (Test-Path $stateFile) {
+        $state = Get-Content -Path $stateFile -Raw
+        $state = $state.Trim()
+        
+        if ($state -eq "INSTALLED") {
+            Write-Message "Uninstalling setuptools (was installed by pre-build)..."
+            python3 -m pip uninstall -y setuptools
+            if ($LASTEXITCODE -eq 0) {
+                Write-Message "> setuptools uninstalled successfully"
+            } else {
+                Write-Message "> Warning: setuptools uninstallation failed"
+            }
+        } elseif ($state -eq "PREEXISTING") {
+            Write-Message "Skipping setuptools cleanup (was pre-existing)"
+        }
+        
+        # Remove state file
+        Remove-Item -Path $stateFile -Force -ErrorAction SilentlyContinue
+    }
+}
+

--- a/custom-steps/pango/pre-build.ps1
+++ b/custom-steps/pango/pre-build.ps1
@@ -9,6 +9,15 @@ if (-not $patchSuccess) {
 }
 
 if ((Get-IsOnMacOS)) {
+    Write-Message "Installing build tools via Homebrew..."
+    
+    # Install build tool prerequisites: autoconf, autoconf-archive, automake, and libtool
+    # On the Mac, there is not a clean way to do this with vcpkg.json like there is on Windows.
+    # The  dependency tree for these tools is somewhat circular and complex on Mac/Linux, and the 
+    # vcpkg maintainers have decided to just assume these tools exist on these environments rather
+    # than building them.  See: https://github.com/microsoft/vcpkg/issues/34723#issuecomment-1824852084
+    brew install autoconf autoconf-archive automake libtool
+    
     Write-Message "Installing setuptools..."
     python3 -m pip install setuptools
 }

--- a/custom-steps/pango/pre-build.ps1
+++ b/custom-steps/pango/pre-build.ps1
@@ -18,7 +18,38 @@ if ((Get-IsOnMacOS)) {
     # than building them.  See: https://github.com/microsoft/vcpkg/issues/34723#issuecomment-1824852084
     brew install autoconf autoconf-archive automake libtool
     
-    Write-Message "Installing setuptools..."
-    python3 -m pip install setuptools
+    Write-Message "Checking for setuptools in user site-packages..."
+    
+    # Check if setuptools exists in user site-packages (not system-wide)
+    $checkScript = @"
+import sys, site, os
+user_site = site.getusersitepackages()
+setuptools_path = os.path.join(user_site, 'setuptools')
+sys.exit(0 if os.path.exists(setuptools_path) else 1)
+"@
+    
+    $setuptoolsInUserSpace = $false
+    python3 -c $checkScript 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        $setuptoolsInUserSpace = $true
+        Write-Message "> setuptools found in user site-packages"
+    } else {
+        Write-Message "> setuptools not found in user site-packages"
+    }
+    
+    # Track whether we installed setuptools (for cleanup in post-build)
+    $stateFile = "$PSScriptRoot/.setuptools-state.txt"
+    if ($setuptoolsInUserSpace) {
+        "PREEXISTING" | Set-Content -Path $stateFile
+    } else {
+        Write-Message "> Installing setuptools to user site-packages..."
+        # Use --break-system-packages with --user for externally-managed Python environments (PEP 668)
+        # This is safe when combined with --user as it installs to user site-packages only
+        python3 -m pip install --user --break-system-packages setuptools
+        if ($LASTEXITCODE -eq 0) {
+            "INSTALLED" | Set-Content -Path $stateFile
+        } else {
+            "FAILED" | Set-Content -Path $stateFile
+        }
+    }
 }
-

--- a/custom-steps/pango/pre-build.ps1
+++ b/custom-steps/pango/pre-build.ps1
@@ -1,6 +1,15 @@
 Import-Module "$PSScriptRoot/../../scripts/ps-modules/Build" -DisableNameChecking
 
+# Apply patch to vcpkg's pango portfile to add Objective-C language support for macOS
+Write-Message "Applying TechSmith patches to vcpkg pango port..."
+$patchSuccess = Apply-VcpkgPortPatch -PortName "pango" -PatchFile "$PSScriptRoot/add-objc-language-support.patch"
+if (-not $patchSuccess) {
+    Write-Message "FATAL: Failed to apply patch to pango port" -Error
+    exit 1
+}
+
 if ((Get-IsOnMacOS)) {
     Write-Message "Installing setuptools..."
     python3 -m pip install setuptools
 }
+

--- a/custom-steps/pango/update-version-info.ps1
+++ b/custom-steps/pango/update-version-info.ps1
@@ -1,0 +1,137 @@
+<#
+.SYNOPSIS
+  Updates fileVersion and productVersion in version-info.json from per-file source manifests.
+
+.DESCRIPTION
+  - Reads a version-info.json file.
+  - For each entry under .files[]:
+      * If "versionSource" is present, combine RootPath + versionSource.
+      * Validate the file exists; if any is missing, stop without writing.
+      * Read the source JSON (e.g., vcpkg.json) and extract the version.
+        Supports common vcpkg manifest keys: version, version-semver, version-string, version-date.
+      * Set fileVersion and productVersion to the extracted version.
+  - Writes the updated version-info.json (UTF‑8 without BOM).
+
+.PARAMETER VersionInfoPath
+  Path to version-info.json to update.
+
+.PARAMETER RootPath
+  The base directory that will be combined with each files[i].versionSource.
+
+.EXAMPLE
+  .\Update-VersionInfo.ps1 -VersionInfoPath .\version-info.json -RootPath C:\dev\vcpkg
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$VersionInfoPath,
+
+    [Parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$RootPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Extract a version from a manifest file using common vcpkg keys (or any key starting with "version")
+function Get-VersionFromManifest {
+    param(
+        [Parameter(Mandatory=$true)]
+        [psobject]$Manifest,
+        [string[]]$CandidateKeys = @('version', 'version-semver', 'version-string', 'version-date')
+    )
+
+    # Try known version keys first
+    foreach ($k in $CandidateKeys) {
+        if ($Manifest.PSObject.Properties.Name -contains $k) {
+            $val = $Manifest.$k
+            if ($null -ne $val -and "$val".Trim()) {
+                return "$val"
+            }
+        }
+    }
+
+    # Fallback pattern: any property starting with "version" except "port-version"
+    $props = $Manifest.PSObject.Properties.Name | Where-Object {
+        $_ -like 'version*' -and $_ -ne 'port-version'
+    }
+    foreach ($p in $props) {
+        $val = $Manifest.$p
+        if ($null -ne $val -and "$val".Trim()) {
+            return "$val"
+        }
+    }
+
+    return $null
+}
+
+# --- Load version-info.json ---
+if (-not (Test-Path -LiteralPath $VersionInfoPath)) {
+    throw "version-info.json not found at: $VersionInfoPath"
+}
+
+try {
+    $versionInfoRaw = Get-Content -LiteralPath $VersionInfoPath -Raw -Encoding UTF8
+    # PS 5.1 compatibility: ConvertFrom-Json has no -Depth parameter
+    $versionInfo = $versionInfoRaw | ConvertFrom-Json
+} catch {
+    throw "Failed to parse JSON from $VersionInfoPath. $_"
+}
+
+if ($null -eq $versionInfo.files -or $versionInfo.files.Count -eq 0) {
+    Write-Warning "No 'files' array found in $VersionInfoPath. Nothing to do."
+    return
+}
+
+
+#--- Single pass: validate + update ---
+$updatedCount = 0
+foreach ($f in $versionInfo.files) {
+
+    # StrictMode-safe guard — skip entries without versionSource
+    if (-not ($f.PSObject.Properties.Name -contains 'versionSource') -or
+        [string]::IsNullOrWhiteSpace($f.versionSource)) {
+        continue
+    }
+
+    $fullPath = Join-Path -Path $RootPath -ChildPath $f.versionSource
+
+    # Validate existence (throws early, before any write happens)
+    if (-not (Test-Path -LiteralPath $fullPath)) {
+        throw "Missing versionSource file for [$($f.filename)]: $fullPath"
+    }
+
+    # Read manifest
+    try {
+        $manifestText = Get-Content -LiteralPath $fullPath -Raw -Encoding UTF8
+        $manifest = $manifestText | ConvertFrom-Json   # PS5‑compatible
+    } catch {
+        throw "Failed to parse manifest JSON at $fullPath. $_"
+    }
+
+    # Extract version
+    $ver = Get-VersionFromManifest -Manifest $manifest
+    if (-not $ver) {
+        throw "No usable version field found in manifest: $fullPath"
+    }
+
+    # Update fields
+    $f.fileVersion = $ver
+    $f.productVersion = $ver
+    $updatedCount++
+}
+
+# --- Write output JSON (UTF-8 without BOM) ---
+try {
+    # Minimal change for Windows PowerShell 5.1: depth cannot exceed 100
+    $outJson = $versionInfo | ConvertTo-Json -Depth 100
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($VersionInfoPath, $outJson, $utf8NoBom)
+
+    Write-Host "Success: updated $updatedCount entries and wrote to $VersionInfoPath"
+} catch {
+    throw "Failed to write updated version-info.json. $_"
+}

--- a/custom-steps/pango/version-info.json
+++ b/custom-steps/pango/version-info.json
@@ -4,6 +4,7 @@
                   {
                       "filename":  "bin/brotlicommon.dll",
                       "fileDescription":  "Brotli common dictionary library",
+                      "versionSource":  "ports/brotli/vcpkg.json",
                       "fileVersion":  "1.1.0",
                       "productName":  "Brotli",
                       "productVersion":  "1.1.0",
@@ -12,6 +13,7 @@
                   {
                       "filename":  "bin/brotlidec.dll",
                       "fileDescription":  "Brotli decoder library",
+                      "versionSource":  "ports/brotli/vcpkg.json",
                       "fileVersion":  "1.1.0",
                       "productName":  "Brotli",
                       "productVersion":  "1.1.0",
@@ -20,6 +22,7 @@
                   {
                       "filename":  "bin/brotlienc.dll",
                       "fileDescription":  "Brotli encoder library",
+                      "versionSource":  "ports/brotli/vcpkg.json",
                       "fileVersion":  "1.1.0",
                       "productName":  "Brotli",
                       "productVersion":  "1.1.0",
@@ -28,6 +31,7 @@
                   {
                       "filename":  "bin/bz2.dll",
                       "fileDescription":  "A program and library for lossless, block-sorting data compression",
+                      "versionSource":  "ports/bzip2/vcpkg.json",
                       "fileVersion":  "1.0.8",
                       "productName":  "Bzip2",
                       "productVersion":  "1.0.8",
@@ -36,6 +40,7 @@
                   {
                       "filename":  "bin/cairo-2.dll",
                       "fileDescription":  "Multi-platform 2D graphics library",
+                      "versionSource":  "ports/cairo/vcpkg.json",
                       "fileVersion":  "1.18.4",
                       "productName":  "Cairo",
                       "productVersion":  "1.18.4",
@@ -44,6 +49,7 @@
                   {
                       "filename":  "bin/cairo-gobject-2.dll",
                       "fileDescription":  "Cairo gobject",
+                      "versionSource":  "ports/cairo/vcpkg.json",
                       "fileVersion":  "1.18.4",
                       "productName":  "Cairo",
                       "productVersion":  "1.18.4",
@@ -52,6 +58,7 @@
                   {
                       "filename":  "bin/cairo-script-interpreter-2.dll",
                       "fileDescription":  "Cairo script interpreter",
+                      "versionSource":  "ports/cairo/vcpkg.json",
                       "fileVersion":  "1.18.4",
                       "productName":  "Cairo",
                       "productVersion":  "1.18.4",
@@ -60,6 +67,7 @@
                   {
                       "filename":  "bin/charset-1.dll",
                       "fileDescription":  "libcharset",
+                      "versionSource":  "ports/libiconv/vcpkg.json",
                       "fileVersion":  "1.5.0",
                       "productName":  "libiconv: character set conversion library",
                       "productVersion":  "1.18",
@@ -68,6 +76,7 @@
                   {
                       "filename":  "bin/ffi-8.dll",
                       "fileDescription":  "libffi",
+                      "versionSource":  "ports/libffi/vcpkg.json",
                       "fileVersion":  "3.5.1",
                       "productName":  "libffi: The portable foreign function interface library",
                       "productVersion":  "3.5.1",
@@ -76,6 +85,7 @@
                   {
                       "filename":  "bin/fontconfig-1.dll",
                       "fileDescription":  "Fontconfig",
+                      "versionSource":  "ports/fontconfig/vcpkg.json",
                       "fileVersion":  "2.15.0",
                       "productName":  "Font configuration and customization library",
                       "productVersion":  "2.15.0",
@@ -84,6 +94,7 @@
                   {
                       "filename":  "bin/freetype.dll",
                       "fileDescription":  "Font Rendering Library",
+                      "versionSource":  "ports/freetype/vcpkg.json",
                       "fileVersion":  "2.13.3",
                       "productName":  "FreeType",
                       "productVersion":  "2.13.3",
@@ -92,6 +103,7 @@
                   {
                       "filename":  "bin/fribidi-0.dll",
                       "fileDescription":  "Unicode Bidirectional Algorithm Library",
+                      "versionSource":  "ports/fribidi/vcpkg.json",
                       "fileVersion":  "1.0.16",
                       "productName":  "GNU FriBidi",
                       "productVersion":  "1.0.16",
@@ -100,6 +112,7 @@
                   {
                       "filename":  "bin/gio-2.0-0.dll",
                       "fileDescription":  "Gio",
+                      "versionSource":  "ports/glib/vcpkg.json",
                       "fileVersion":  "2.84.2",
                       "productName":  "GLib",
                       "productVersion":  "2.84.2",
@@ -108,6 +121,7 @@
                   {
                       "filename":  "bin/girepository-2.0-0.dll",
                       "fileDescription":  "GObject Introspection repository parser",
+                      "versionSource":  "ports/glib/vcpkg.json",
                       "fileVersion":  "2.84.2",
                       "productName":  "GLib",
                       "productVersion":  "2.84.2",
@@ -116,6 +130,7 @@
                   {
                       "filename":  "bin/glib-2.0-0.dll",
                       "fileDescription":  "GLib",
+                      "versionSource":  "ports/glib/vcpkg.json",
                       "fileVersion":  "2.84.2",
                       "productName":  "GLib",
                       "productVersion":  "2.84.2",
@@ -124,6 +139,7 @@
                   {
                       "filename":  "bin/gmodule-2.0-0.dll",
                       "fileDescription":  "GModule",
+                      "versionSource":  "ports/glib/vcpkg.json",
                       "fileVersion":  "2.84.2",
                       "productName":  "GLib",
                       "productVersion":  "22.84.2",
@@ -132,6 +148,7 @@
                   {
                       "filename":  "bin/gobject-2.0-0.dll",
                       "fileDescription":  "GObject",
+                      "versionSource":  "ports/glib/vcpkg.json",
                       "fileVersion":  "2.84.2",
                       "productName":  "GLib",
                       "productVersion":  "2.84.2",
@@ -140,6 +157,7 @@
                   {
                       "filename":  "bin/gthread-2.0-0.dll",
                       "fileDescription":  "GThread",
+                      "versionSource":  "ports/glib/vcpkg.json",
                       "fileVersion":  "2.84.2",
                       "productName":  "GLib",
                       "productVersion":  "2.84.2",
@@ -148,6 +166,7 @@
                   {
                       "filename":  "bin/harfbuzz-subset.dll",
                       "fileDescription":  "HarfBuzz font subsetter",
+                      "versionSource":  "ports/harfbuzz/vcpkg.json",
                       "fileVersion":  "10.2.0",
                       "productName":  "Harfbuzz",
                       "productVersion":  "10.2.0",
@@ -156,6 +175,7 @@
                   {
                       "filename":  "bin/harfbuzz.dll",
                       "fileDescription":  "HarfBuzz text shaping library",
+                      "versionSource":  "ports/harfbuzz/vcpkg.json",
                       "fileVersion":  "10.2.0",
                       "productName":  "Harfbuzz",
                       "productVersion":  "10.2.0",
@@ -164,6 +184,7 @@
                   {
                       "filename":  "bin/iconv-2.dll",
                       "fileDescription":  "LGPLed libiconv for Windows",
+                      "versionSource":  "ports/libiconv/vcpkg.json",
                       "fileVersion":  "1.18",
                       "productName":  "libiconv: character set conversion library",
                       "productVersion":  "1.18",
@@ -172,6 +193,7 @@
                   {
                       "filename":  "bin/intl-8.dll",
                       "fileDescription":  "LGPLed libintl for Windows",
+                      "versionSource":  "ports/gettext-libintl/vcpkg.json",
                       "fileVersion":  "0.22.5",
                       "productName":  "GNU libintl: accessing NLS message catalogs",
                       "productVersion":  "0.22.5",
@@ -180,6 +202,7 @@
                   {
                       "filename":  "bin/libexpat.dll",
                       "fileDescription":  "Expat XML parser",
+                      "versionSource":  "ports/expat/vcpkg.json",
                       "fileVersion":  "2.7.1",
                       "productName":  "Expat",
                       "productVersion":  "2.7.1",
@@ -188,6 +211,7 @@
                   {
                       "filename":  "bin/libpng16.dll",
                       "fileDescription":  "Loads and saves PNG files",
+                      "versionSource":  "ports/libpng/vcpkg.json",
                       "fileVersion":  "1.6.47",
                       "productName":  "libpng",
                       "productVersion":  "1.6.47",
@@ -196,6 +220,7 @@
                   {
                       "filename":  "bin/pango-1.0-0.dll",
                       "fileDescription":  "Pango",
+                      "versionSource":  "ports/pango/vcpkg.json",
                       "fileVersion":  "1.56.1",
                       "productName":  "Pango",
                       "productVersion":  "1.56.1",
@@ -204,6 +229,7 @@
                   {
                       "filename":  "bin/pangocairo-1.0-0.dll",
                       "fileDescription":  "PangoCairo",
+                      "versionSource":  "ports/pango/vcpkg.json",
                       "fileVersion":  "1.56.1",
                       "productName":  "PangoCairo",
                       "productVersion":  "1.56.1",
@@ -212,6 +238,7 @@
                   {
                       "filename":  "bin/pangoft2-1.0-0.dll",
                       "fileDescription":  "PangoFT2",
+                      "versionSource":  "ports/pango/vcpkg.json",
                       "fileVersion":  "1.56.1",
                       "productName":  "PangoFT2",
                       "productVersion":  "1.56.1",
@@ -220,6 +247,7 @@
                   {
                       "filename":  "bin/pangowin32-1.0-0.dll",
                       "fileDescription":  "PangoWin32",
+                      "versionSource":  "ports/pango/vcpkg.json",
                       "fileVersion":  "1.56.1",
                       "productName":  "PangoWin32",
                       "productVersion":  "1.56.1",
@@ -228,6 +256,7 @@
                   {
                       "filename":  "bin/pcre2-16.dll",
                       "fileDescription":  "PCRE2 - Perl compatible regular expressions C library (2nd API) with 16 bit character support",
+                      "versionSource":  "ports/pcre2/vcpkg.json",
                       "fileVersion":  "12.0.2",
                       "productName":  "libpcre2-16",
                       "productVersion":  "12.0.2",
@@ -236,6 +265,7 @@
                   {
                       "filename":  "bin/pcre2-32.dll",
                       "fileDescription":  "PCRE2 - Perl compatible regular expressions C library (2nd API) with 32 bit character support",
+                      "versionSource":  "ports/pcre2/vcpkg.json",
                       "fileVersion":  "12.0.2",
                       "productName":  "libpcre2-32",
                       "productVersion":  "12.0.2",
@@ -244,6 +274,7 @@
                   {
                       "filename":  "bin/pcre2-8.dll",
                       "fileDescription":  "PCRE2 - Perl compatible regular expressions C library (2nd API) with 8 bit character support",
+                      "versionSource":  "ports/pcre2/vcpkg.json",
                       "fileVersion":  "12.0.2",
                       "productName":  "libpcre2-8",
                       "productVersion":  "12.0.2",
@@ -252,6 +283,7 @@
                   {
                       "filename":  "bin/pcre2-posix.dll",
                       "fileDescription":  "Posix compatible interface to libpcre2-8",
+                      "versionSource":  "ports/pcre2/vcpkg.json",
                       "fileVersion":  "3.5.0",
                       "productName":  "libpcre2-posix",
                       "productVersion":  "3.5.0",
@@ -260,6 +292,7 @@
                   {
                       "filename":  "bin/pixman-1-0.dll",
                       "fileDescription":  "The pixman library (version 1)",
+                      "versionSource":  "ports/pixman/vcpkg.json",
                       "fileVersion":  "0.44.2",
                       "productName":  "Pixman",
                       "productVersion":  "0.44.2",
@@ -268,6 +301,7 @@
                   {
                       "filename":  "bin/pthreadVC3.dll",
                       "fileDescription":  "MS C x64",
+                      "versionSource":  "ports/pthread/vcpkg.json",
                       "fileVersion":  "3.0.0",
                       "productName":  "POSIX Threads for Windows",
                       "productVersion":  "3.0.0",
@@ -276,6 +310,7 @@
                   {
                       "filename":  "bin/pthreadVCE3.dll",
                       "fileDescription":  "MS C++ x64",
+                      "versionSource":  "ports/pthread/vcpkg.json",
                       "fileVersion":  "3.0.0",
                       "productName":  "POSIX Threads for Windows",
                       "productVersion":  "3.0.0",
@@ -284,6 +319,7 @@
                   {
                       "filename":  "bin/pthreadVSE3.dll",
                       "fileDescription":  "MS C SEH x64",
+                      "versionSource":  "ports/pthread/vcpkg.json",
                       "fileVersion":  "3.0.0",
                       "productName":  "POSIX Threads for Windows",
                       "productVersion":  "3.0.0",
@@ -292,6 +328,7 @@
                   {
                       "filename":  "bin/zlib1.dll",
                       "fileDescription":  "zlib data compression library",
+                      "versionSource":  "ports/zlib/vcpkg.json",
                       "fileVersion":  "1.3.1",
                       "productName":  "zlib",
                       "productVersion":  "1.3.1",

--- a/custom-steps/pango/version-info.json
+++ b/custom-steps/pango/version-info.json
@@ -1,301 +1,301 @@
 {
-  "buildNumber": 101,
-  "files": [
-    {
-      "filename": "bin/brotlicommon.dll",
-      "fileDescription": "Brotli common dictionary library",
-      "fileVersion": "1.1.0",
-      "productName": "Brotli",
-      "productVersion": "1.1.0",
-      "copyright": "Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors."
-    },
-    {
-      "filename": "bin/brotlidec.dll",
-      "fileDescription": "Brotli decoder library",
-      "fileVersion": "1.1.0",
-      "productName": "Brotli",
-      "productVersion": "1.1.0",
-      "copyright": "Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors."
-    },
-    {
-      "filename": "bin/brotlienc.dll",
-      "fileDescription": "Brotli encoder library",
-      "fileVersion": "1.1.0",
-      "productName": "Brotli",
-      "productVersion": "1.1.0",
-      "copyright": "Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors."
-    },
-    {
-      "filename": "bin/bz2.dll",
-      "fileDescription": "A program and library for lossless, block-sorting data compression",
-      "fileVersion": "1.0.8",
-      "productName": "Bzip2",
-      "productVersion": "1.0.8",
-      "copyright": "Copyright (C) 1996-2019 Julian R Seward"
-    },
-    {
-      "filename": "bin/cairo-2.dll",
-      "fileDescription": "Multi-platform 2D graphics library",
-      "fileVersion": "1.18.4",
-      "productName": "Cairo",
-      "productVersion": "1.18.4",
-      "copyright": "Copyright (c) 2003-2025 The Cairo Authors"
-    },
-    {
-      "filename": "bin/cairo-gobject-2.dll",
-      "fileDescription": "Cairo gobject",
-      "fileVersion": "1.18.4",
-      "productName": "Cairo",
-      "productVersion": "1.18.4",
-      "copyright": "Copyright (c) 2003-2025 The Cairo Authors"
-    },
-    {
-      "filename": "bin/cairo-script-interpreter-2.dll",
-      "fileDescription": "Cairo script interpreter",
-      "fileVersion": "1.18.4",
-      "productName": "Cairo",
-      "productVersion": "1.18.4",
-      "copyright": "Copyright (c) 2003-2025 The Cairo Authors"
-    },
-    {
-      "filename": "bin/charset-1.dll",
-      "fileDescription": "libcharset",
-      "fileVersion": "1.5.0",
-      "productName": "libiconv: character set conversion library",
-      "productVersion": "1.18",
-      "copyright": "Copyright (C) 1999-2022"
-    },
-    {
-      "filename": "bin/ffi-8.dll",
-      "fileDescription": "libffi",
-      "fileVersion": "3.5.1",
-      "productName": "libffi: The portable foreign function interface library",
-      "productVersion": "3.5.1",
-      "copyright": "Copyright (c) 1996-2024  Anthony Green, Red Hat, Inc and others."
-    },
-    {
-      "filename": "bin/fontconfig-1.dll",
-      "fileDescription": "Fontconfig",
-      "fileVersion": "2.15.0",
-      "productName": "Font configuration and customization library",
-      "productVersion": "2.15.0",
-      "copyright": "Copyright (c) 2000-2020 Keith Packard, Patrick Lam and others"
-    },
-    {
-      "filename": "bin/freetype.dll",
-      "fileDescription": "Font Rendering Library",
-      "fileVersion": "2.13.3",
-      "productName": "FreeType",
-      "productVersion": "2.13.3",
-      "copyright": "© 2000-2024 The FreeType Project www.freetype.org. All rights reserved."
-    },
-    {
-      "filename": "bin/fribidi-0.dll",
-      "fileDescription": "Unicode Bidirectional Algorithm Library",
-      "fileVersion": "1.0.16",
-      "productName": "GNU FriBidi",
-      "productVersion": "1.0.16",
-      "copyright": "Copyright (C) 2004 Sharif FarsiWeb, Inc"
-    },
-    {
-      "filename": "bin/gio-2.0-0.dll",
-      "fileDescription": "Gio",
-      "fileVersion": "2.84.2",
-      "productName": "GLib",
-      "productVersion": "2.84.2",
-      "copyright": "Copyright 2006-2011 Red Hat, Inc. and others."
-    },
-    {
-      "filename": "bin/girepository-2.0-0.dll",
-      "fileDescription": "GObject Introspection repository parser",
-      "fileVersion": "2.84.2",
-      "productName": "GLib",
-      "productVersion": "2.84.2",
-      "copyright": "Copyright (C) 2005-2025 Matthias Clasen, Red Hat, Inc. and others"
-    },
-    {
-      "filename": "bin/glib-2.0-0.dll",
-      "fileDescription": "GLib",
-      "fileVersion": "2.84.2",
-      "productName": "GLib",
-      "productVersion": "2.84.2",
-      "copyright": "Copyright 1995-2011 Peter Mattis, Spencer Kimball, Josh MacDonald and others."
-    },
-    {
-      "filename": "bin/gmodule-2.0-0.dll",
-      "fileDescription": "GModule",
-      "fileVersion": "2.84.2",
-      "productName": "GLib",
-      "productVersion": "22.84.2",
-      "copyright": "Copyright 1998-2011 Tim Janik and others."
-    },
-    {
-      "filename": "bin/gobject-2.0-0.dll",
-      "fileDescription": "GObject",
-      "fileVersion": "2.84.2",
-      "productName": "GLib",
-      "productVersion": "2.84.2",
-      "copyright": "Copyright 1998-2011 Tim Janik, Red Hat, Inc. and others"
-    },
-    {
-      "filename": "bin/gthread-2.0-0.dll",
-      "fileDescription": "GThread",
-      "fileVersion": "2.84.2",
-      "productName": "GLib",
-      "productVersion": "2.84.2",
-      "copyright": "Copyright 1995-2011 Peter Mattis, Spencer Kimball, Josh MacDonald, Sebastian Wilhelmi and others."
-    },
-    {
-      "filename": "bin/harfbuzz-subset.dll",
-      "fileDescription": "HarfBuzz font subsetter",
-      "fileVersion": "10.2.0",
-      "productName": "Harfbuzz",
-      "productVersion": "10.2.0",
-      "copyright": "Copyright © 2010-2022 Google, Inc. and others"
-    },
-    {
-      "filename": "bin/harfbuzz.dll",
-      "fileDescription": "HarfBuzz text shaping library",
-      "fileVersion": "10.2.0",
-      "productName": "Harfbuzz",
-      "productVersion": "10.2.0",
-      "copyright": "Copyright © 2010-2022 Google, Inc. and others"
-    },
-    {
-      "filename": "bin/iconv-2.dll",
-      "fileDescription": "LGPLed libiconv for Windows",
-      "fileVersion": "1.18",
-      "productName": "libiconv: character set conversion library",
-      "productVersion": "1.18",
-      "copyright": "Copyright (C) 1999-2022"
-    },
-    {
-      "filename": "bin/intl-8.dll",
-      "fileDescription": "LGPLed libintl for Windows",
-      "fileVersion": "0.22.5",
-      "productName": "GNU libintl: accessing NLS message catalogs",
-      "productVersion": "0.22.5",
-      "copyright": "Copyright (C) 1995-2019"
-    },
-    {
-      "filename": "bin/libexpat.dll",
-      "fileDescription": "Expat XML parser",
-      "fileVersion": "2.7.1",
-      "productName": "Expat",
-      "productVersion": "2.7.1",
-      "copyright": "Copyright (c) 2001-2022 Expat maintainers"
-    },
-    {
-      "filename": "bin/libpng16.dll",
-      "fileDescription": "Loads and saves PNG files",
-      "fileVersion": "1.6.47",
-      "productName": "libpng",
-      "productVersion": "1.6.47",
-      "copyright": "Copyright (c) 1995-2025 The PNG Reference Library Authors."
-    },
-    {
-      "filename": "bin/pango-1.0-0.dll",
-      "fileDescription": "Pango",
-      "fileVersion": "1.56.1",
-      "productName": "Pango",
-      "productVersion": "1.56.1",
-      "copyright": "Copyright 1999 Red Hat Software."
-    },
-    {
-      "filename": "bin/pangocairo-1.0-0.dll",
-      "fileDescription": "PangoCairo",
-      "fileVersion": "1.56.1",
-      "productName": "PangoCairo",
-      "productVersion": "1.56.1",
-      "copyright": "Copyright 2010 Red Hat Software."
-    },
-    {
-      "filename": "bin/pangoft2-1.0-0.dll",
-      "fileDescription": "PangoFT2",
-      "fileVersion": "1.56.1",
-      "productName": "PangoFT2",
-      "productVersion": "1.56.1",
-      "copyright": "Copyright 1999 Red Hat Software. Copyright 2000 Tor Lillqvist"
-    },
-    {
-      "filename": "bin/pangowin32-1.0-0.dll",
-      "fileDescription": "PangoWin32",
-      "fileVersion": "1.56.1",
-      "productName": "PangoWin32",
-      "productVersion": "1.56.1",
-      "copyright": "Copyright 1999 Red Hat Software. Copyright 2000 Tor Lillqvist"
-    },
-    {
-      "filename": "bin/pcre2-16.dll",
-      "fileDescription": "PCRE2 - Perl compatible regular expressions C library (2nd API) with 16 bit character support",
-      "fileVersion": "12.0.2",
-      "productName": "libpcre2-16",
-      "productVersion": "12.0.2",
-      "copyright": "Copyright (c) 1997-2024 University of Cambridge and others"
-    },
-    {
-      "filename": "bin/pcre2-32.dll",
-      "fileDescription": "PCRE2 - Perl compatible regular expressions C library (2nd API) with 32 bit character support",
-      "fileVersion": "12.0.2",
-      "productName": "libpcre2-32",
-      "productVersion": "12.0.2",
-      "copyright": "Copyright (c) 1997-2024 University of Cambridge and others"
-    },
-    {
-      "filename": "bin/pcre2-8.dll",
-      "fileDescription": "PCRE2 - Perl compatible regular expressions C library (2nd API) with 8 bit character support",
-      "fileVersion": "12.0.2",
-      "productName": "libpcre2-8",
-      "productVersion": "12.0.2",
-      "copyright": "Copyright (c) 1997-2024 University of Cambridge and others"
-    },
-    {
-      "filename": "bin/pcre2-posix.dll",
-      "fileDescription": "Posix compatible interface to libpcre2-8",
-      "fileVersion": "3.5.0",
-      "productName": "libpcre2-posix",
-      "productVersion": "3.5.0",
-      "copyright": "Copyright (c) 1997-2024 University of Cambridge and others"
-    },
-    {
-      "filename": "bin/pixman-1-0.dll",
-      "fileDescription": "The pixman library (version 1)",
-      "fileVersion": "0.44.2",
-      "productName": "Pixman",
-      "productVersion": "0.44.2",
-      "copyright": "Copyright (c) 1997-2010 Red Hat, Inc. and others"
-    },
-    {
-      "filename": "bin/pthreadVC3.dll",
-      "fileDescription": "MS C x64",
-      "fileVersion": "3.0.0",
-      "productName": "POSIX Threads for Windows",
-      "productVersion": "3.0.0",
-      "copyright": "Copyright - Project contributors 1999-2016"
-    },
-    {
-      "filename": "bin/pthreadVCE3.dll",
-      "fileDescription": "MS C++ x64",
-      "fileVersion": "3.0.0",
-      "productName": "POSIX Threads for Windows",
-      "productVersion": "3.0.0",
-      "copyright": "Copyright - Project contributors 1999-2016"
-    },
-    {
-      "filename": "bin/pthreadVSE3.dll",
-      "fileDescription": "MS C SEH x64",
-      "fileVersion": "3.0.0",
-      "productName": "POSIX Threads for Windows",
-      "productVersion": "3.0.0",
-      "copyright": "Copyright - Project contributors 1999-2016"
-    },
-    {
-      "filename": "bin/zlib1.dll",
-      "fileDescription": "zlib data compression library",
-      "fileVersion": "1.3.1",
-      "productName": "zlib",
-      "productVersion": "1.3.1",
-      "copyright": "(C) 1995-2022 Jean-loup Gailly & Mark Adler"
-    }
-  ]
+    "buildNumber":  101,
+    "files":  [
+                  {
+                      "filename":  "bin/brotlicommon.dll",
+                      "fileDescription":  "Brotli common dictionary library",
+                      "fileVersion":  "1.1.0",
+                      "productName":  "Brotli",
+                      "productVersion":  "1.1.0",
+                      "copyright":  "Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors."
+                  },
+                  {
+                      "filename":  "bin/brotlidec.dll",
+                      "fileDescription":  "Brotli decoder library",
+                      "fileVersion":  "1.1.0",
+                      "productName":  "Brotli",
+                      "productVersion":  "1.1.0",
+                      "copyright":  "Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors."
+                  },
+                  {
+                      "filename":  "bin/brotlienc.dll",
+                      "fileDescription":  "Brotli encoder library",
+                      "fileVersion":  "1.1.0",
+                      "productName":  "Brotli",
+                      "productVersion":  "1.1.0",
+                      "copyright":  "Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors."
+                  },
+                  {
+                      "filename":  "bin/bz2.dll",
+                      "fileDescription":  "A program and library for lossless, block-sorting data compression",
+                      "fileVersion":  "1.0.8",
+                      "productName":  "Bzip2",
+                      "productVersion":  "1.0.8",
+                      "copyright":  "Copyright (C) 1996-2019 Julian R Seward"
+                  },
+                  {
+                      "filename":  "bin/cairo-2.dll",
+                      "fileDescription":  "Multi-platform 2D graphics library",
+                      "fileVersion":  "1.18.4",
+                      "productName":  "Cairo",
+                      "productVersion":  "1.18.4",
+                      "copyright":  "Copyright (c) 2003-2025 The Cairo Authors"
+                  },
+                  {
+                      "filename":  "bin/cairo-gobject-2.dll",
+                      "fileDescription":  "Cairo gobject",
+                      "fileVersion":  "1.18.4",
+                      "productName":  "Cairo",
+                      "productVersion":  "1.18.4",
+                      "copyright":  "Copyright (c) 2003-2025 The Cairo Authors"
+                  },
+                  {
+                      "filename":  "bin/cairo-script-interpreter-2.dll",
+                      "fileDescription":  "Cairo script interpreter",
+                      "fileVersion":  "1.18.4",
+                      "productName":  "Cairo",
+                      "productVersion":  "1.18.4",
+                      "copyright":  "Copyright (c) 2003-2025 The Cairo Authors"
+                  },
+                  {
+                      "filename":  "bin/charset-1.dll",
+                      "fileDescription":  "libcharset",
+                      "fileVersion":  "1.5.0",
+                      "productName":  "libiconv: character set conversion library",
+                      "productVersion":  "1.18",
+                      "copyright":  "Copyright (C) 1999-2022"
+                  },
+                  {
+                      "filename":  "bin/ffi-8.dll",
+                      "fileDescription":  "libffi",
+                      "fileVersion":  "3.5.1",
+                      "productName":  "libffi: The portable foreign function interface library",
+                      "productVersion":  "3.5.1",
+                      "copyright":  "Copyright (c) 1996-2024  Anthony Green, Red Hat, Inc and others."
+                  },
+                  {
+                      "filename":  "bin/fontconfig-1.dll",
+                      "fileDescription":  "Fontconfig",
+                      "fileVersion":  "2.15.0",
+                      "productName":  "Font configuration and customization library",
+                      "productVersion":  "2.15.0",
+                      "copyright":  "Copyright (c) 2000-2020 Keith Packard, Patrick Lam and others"
+                  },
+                  {
+                      "filename":  "bin/freetype.dll",
+                      "fileDescription":  "Font Rendering Library",
+                      "fileVersion":  "2.13.3",
+                      "productName":  "FreeType",
+                      "productVersion":  "2.13.3",
+                      "copyright":  "© 2000-2024 The FreeType Project www.freetype.org. All rights reserved."
+                  },
+                  {
+                      "filename":  "bin/fribidi-0.dll",
+                      "fileDescription":  "Unicode Bidirectional Algorithm Library",
+                      "fileVersion":  "1.0.16",
+                      "productName":  "GNU FriBidi",
+                      "productVersion":  "1.0.16",
+                      "copyright":  "Copyright (C) 2004 Sharif FarsiWeb, Inc"
+                  },
+                  {
+                      "filename":  "bin/gio-2.0-0.dll",
+                      "fileDescription":  "Gio",
+                      "fileVersion":  "2.84.2",
+                      "productName":  "GLib",
+                      "productVersion":  "2.84.2",
+                      "copyright":  "Copyright 2006-2011 Red Hat, Inc. and others."
+                  },
+                  {
+                      "filename":  "bin/girepository-2.0-0.dll",
+                      "fileDescription":  "GObject Introspection repository parser",
+                      "fileVersion":  "2.84.2",
+                      "productName":  "GLib",
+                      "productVersion":  "2.84.2",
+                      "copyright":  "Copyright (C) 2005-2025 Matthias Clasen, Red Hat, Inc. and others"
+                  },
+                  {
+                      "filename":  "bin/glib-2.0-0.dll",
+                      "fileDescription":  "GLib",
+                      "fileVersion":  "2.84.2",
+                      "productName":  "GLib",
+                      "productVersion":  "2.84.2",
+                      "copyright":  "Copyright 1995-2011 Peter Mattis, Spencer Kimball, Josh MacDonald and others."
+                  },
+                  {
+                      "filename":  "bin/gmodule-2.0-0.dll",
+                      "fileDescription":  "GModule",
+                      "fileVersion":  "2.84.2",
+                      "productName":  "GLib",
+                      "productVersion":  "22.84.2",
+                      "copyright":  "Copyright 1998-2011 Tim Janik and others."
+                  },
+                  {
+                      "filename":  "bin/gobject-2.0-0.dll",
+                      "fileDescription":  "GObject",
+                      "fileVersion":  "2.84.2",
+                      "productName":  "GLib",
+                      "productVersion":  "2.84.2",
+                      "copyright":  "Copyright 1998-2011 Tim Janik, Red Hat, Inc. and others"
+                  },
+                  {
+                      "filename":  "bin/gthread-2.0-0.dll",
+                      "fileDescription":  "GThread",
+                      "fileVersion":  "2.84.2",
+                      "productName":  "GLib",
+                      "productVersion":  "2.84.2",
+                      "copyright":  "Copyright 1995-2011 Peter Mattis, Spencer Kimball, Josh MacDonald, Sebastian Wilhelmi and others."
+                  },
+                  {
+                      "filename":  "bin/harfbuzz-subset.dll",
+                      "fileDescription":  "HarfBuzz font subsetter",
+                      "fileVersion":  "10.2.0",
+                      "productName":  "Harfbuzz",
+                      "productVersion":  "10.2.0",
+                      "copyright":  "Copyright © 2010-2022 Google, Inc. and others"
+                  },
+                  {
+                      "filename":  "bin/harfbuzz.dll",
+                      "fileDescription":  "HarfBuzz text shaping library",
+                      "fileVersion":  "10.2.0",
+                      "productName":  "Harfbuzz",
+                      "productVersion":  "10.2.0",
+                      "copyright":  "Copyright © 2010-2022 Google, Inc. and others"
+                  },
+                  {
+                      "filename":  "bin/iconv-2.dll",
+                      "fileDescription":  "LGPLed libiconv for Windows",
+                      "fileVersion":  "1.18",
+                      "productName":  "libiconv: character set conversion library",
+                      "productVersion":  "1.18",
+                      "copyright":  "Copyright (C) 1999-2022"
+                  },
+                  {
+                      "filename":  "bin/intl-8.dll",
+                      "fileDescription":  "LGPLed libintl for Windows",
+                      "fileVersion":  "0.22.5",
+                      "productName":  "GNU libintl: accessing NLS message catalogs",
+                      "productVersion":  "0.22.5",
+                      "copyright":  "Copyright (C) 1995-2019"
+                  },
+                  {
+                      "filename":  "bin/libexpat.dll",
+                      "fileDescription":  "Expat XML parser",
+                      "fileVersion":  "2.7.1",
+                      "productName":  "Expat",
+                      "productVersion":  "2.7.1",
+                      "copyright":  "Copyright (c) 2001-2022 Expat maintainers"
+                  },
+                  {
+                      "filename":  "bin/libpng16.dll",
+                      "fileDescription":  "Loads and saves PNG files",
+                      "fileVersion":  "1.6.47",
+                      "productName":  "libpng",
+                      "productVersion":  "1.6.47",
+                      "copyright":  "Copyright (c) 1995-2025 The PNG Reference Library Authors."
+                  },
+                  {
+                      "filename":  "bin/pango-1.0-0.dll",
+                      "fileDescription":  "Pango",
+                      "fileVersion":  "1.56.1",
+                      "productName":  "Pango",
+                      "productVersion":  "1.56.1",
+                      "copyright":  "Copyright 1999 Red Hat Software."
+                  },
+                  {
+                      "filename":  "bin/pangocairo-1.0-0.dll",
+                      "fileDescription":  "PangoCairo",
+                      "fileVersion":  "1.56.1",
+                      "productName":  "PangoCairo",
+                      "productVersion":  "1.56.1",
+                      "copyright":  "Copyright 2010 Red Hat Software."
+                  },
+                  {
+                      "filename":  "bin/pangoft2-1.0-0.dll",
+                      "fileDescription":  "PangoFT2",
+                      "fileVersion":  "1.56.1",
+                      "productName":  "PangoFT2",
+                      "productVersion":  "1.56.1",
+                      "copyright":  "Copyright 1999 Red Hat Software. Copyright 2000 Tor Lillqvist"
+                  },
+                  {
+                      "filename":  "bin/pangowin32-1.0-0.dll",
+                      "fileDescription":  "PangoWin32",
+                      "fileVersion":  "1.56.1",
+                      "productName":  "PangoWin32",
+                      "productVersion":  "1.56.1",
+                      "copyright":  "Copyright 1999 Red Hat Software. Copyright 2000 Tor Lillqvist"
+                  },
+                  {
+                      "filename":  "bin/pcre2-16.dll",
+                      "fileDescription":  "PCRE2 - Perl compatible regular expressions C library (2nd API) with 16 bit character support",
+                      "fileVersion":  "12.0.2",
+                      "productName":  "libpcre2-16",
+                      "productVersion":  "12.0.2",
+                      "copyright":  "Copyright (c) 1997-2024 University of Cambridge and others"
+                  },
+                  {
+                      "filename":  "bin/pcre2-32.dll",
+                      "fileDescription":  "PCRE2 - Perl compatible regular expressions C library (2nd API) with 32 bit character support",
+                      "fileVersion":  "12.0.2",
+                      "productName":  "libpcre2-32",
+                      "productVersion":  "12.0.2",
+                      "copyright":  "Copyright (c) 1997-2024 University of Cambridge and others"
+                  },
+                  {
+                      "filename":  "bin/pcre2-8.dll",
+                      "fileDescription":  "PCRE2 - Perl compatible regular expressions C library (2nd API) with 8 bit character support",
+                      "fileVersion":  "12.0.2",
+                      "productName":  "libpcre2-8",
+                      "productVersion":  "12.0.2",
+                      "copyright":  "Copyright (c) 1997-2024 University of Cambridge and others"
+                  },
+                  {
+                      "filename":  "bin/pcre2-posix.dll",
+                      "fileDescription":  "Posix compatible interface to libpcre2-8",
+                      "fileVersion":  "3.5.0",
+                      "productName":  "libpcre2-posix",
+                      "productVersion":  "3.5.0",
+                      "copyright":  "Copyright (c) 1997-2024 University of Cambridge and others"
+                  },
+                  {
+                      "filename":  "bin/pixman-1-0.dll",
+                      "fileDescription":  "The pixman library (version 1)",
+                      "fileVersion":  "0.44.2",
+                      "productName":  "Pixman",
+                      "productVersion":  "0.44.2",
+                      "copyright":  "Copyright (c) 1997-2010 Red Hat, Inc. and others"
+                  },
+                  {
+                      "filename":  "bin/pthreadVC3.dll",
+                      "fileDescription":  "MS C x64",
+                      "fileVersion":  "3.0.0",
+                      "productName":  "POSIX Threads for Windows",
+                      "productVersion":  "3.0.0",
+                      "copyright":  "Copyright - Project contributors 1999-2016"
+                  },
+                  {
+                      "filename":  "bin/pthreadVCE3.dll",
+                      "fileDescription":  "MS C++ x64",
+                      "fileVersion":  "3.0.0",
+                      "productName":  "POSIX Threads for Windows",
+                      "productVersion":  "3.0.0",
+                      "copyright":  "Copyright - Project contributors 1999-2016"
+                  },
+                  {
+                      "filename":  "bin/pthreadVSE3.dll",
+                      "fileDescription":  "MS C SEH x64",
+                      "fileVersion":  "3.0.0",
+                      "productName":  "POSIX Threads for Windows",
+                      "productVersion":  "3.0.0",
+                      "copyright":  "Copyright - Project contributors 1999-2016"
+                  },
+                  {
+                      "filename":  "bin/zlib1.dll",
+                      "fileDescription":  "zlib data compression library",
+                      "fileVersion":  "1.3.1",
+                      "productName":  "zlib",
+                      "productVersion":  "1.3.1",
+                      "copyright":  "(C) 1995-2022 Jean-loup Gailly \u0026 Mark Adler"
+                  }
+              ]
 }

--- a/custom-steps/pango/version-info.json
+++ b/custom-steps/pango/version-info.json
@@ -256,7 +256,7 @@
                   {
                       "filename":  "bin/pcre2-16.dll",
                       "fileDescription":  "PCRE2 - Perl compatible regular expressions C library (2nd API) with 16 bit character support",
-                      "versionSource":  "ports/pcre2/vcpkg.json",
+                      "__comment__versionSource":  "ports/pcre2/vcpkg.json",
                       "fileVersion":  "12.0.2",
                       "productName":  "libpcre2-16",
                       "productVersion":  "12.0.2",
@@ -265,7 +265,7 @@
                   {
                       "filename":  "bin/pcre2-32.dll",
                       "fileDescription":  "PCRE2 - Perl compatible regular expressions C library (2nd API) with 32 bit character support",
-                      "versionSource":  "ports/pcre2/vcpkg.json",
+                      "__comment__versionSource":  "ports/pcre2/vcpkg.json",
                       "fileVersion":  "12.0.2",
                       "productName":  "libpcre2-32",
                       "productVersion":  "12.0.2",
@@ -274,7 +274,7 @@
                   {
                       "filename":  "bin/pcre2-8.dll",
                       "fileDescription":  "PCRE2 - Perl compatible regular expressions C library (2nd API) with 8 bit character support",
-                      "versionSource":  "ports/pcre2/vcpkg.json",
+                      "__comment__versionSource":  "ports/pcre2/vcpkg.json",
                       "fileVersion":  "12.0.2",
                       "productName":  "libpcre2-8",
                       "productVersion":  "12.0.2",

--- a/custom-steps/pango/version-info.json
+++ b/custom-steps/pango/version-info.json
@@ -5,27 +5,27 @@
                       "filename":  "bin/brotlicommon.dll",
                       "fileDescription":  "Brotli common dictionary library",
                       "versionSource":  "ports/brotli/vcpkg.json",
-                      "fileVersion":  "1.1.0",
+                      "fileVersion":  "1.2.0",
                       "productName":  "Brotli",
-                      "productVersion":  "1.1.0",
+                      "productVersion":  "1.2.0",
                       "copyright":  "Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors."
                   },
                   {
                       "filename":  "bin/brotlidec.dll",
                       "fileDescription":  "Brotli decoder library",
                       "versionSource":  "ports/brotli/vcpkg.json",
-                      "fileVersion":  "1.1.0",
+                      "fileVersion":  "1.2.0",
                       "productName":  "Brotli",
-                      "productVersion":  "1.1.0",
+                      "productVersion":  "1.2.0",
                       "copyright":  "Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors."
                   },
                   {
                       "filename":  "bin/brotlienc.dll",
                       "fileDescription":  "Brotli encoder library",
                       "versionSource":  "ports/brotli/vcpkg.json",
-                      "fileVersion":  "1.1.0",
+                      "fileVersion":  "1.2.0",
                       "productName":  "Brotli",
-                      "productVersion":  "1.1.0",
+                      "productVersion":  "1.2.0",
                       "copyright":  "Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors."
                   },
                   {
@@ -68,7 +68,7 @@
                       "filename":  "bin/charset-1.dll",
                       "fileDescription":  "libcharset",
                       "versionSource":  "ports/libiconv/vcpkg.json",
-                      "fileVersion":  "1.5.0",
+                      "fileVersion":  "1.18",
                       "productName":  "libiconv: character set conversion library",
                       "productVersion":  "1.18",
                       "copyright":  "Copyright (C) 1999-2022"
@@ -77,18 +77,18 @@
                       "filename":  "bin/ffi-8.dll",
                       "fileDescription":  "libffi",
                       "versionSource":  "ports/libffi/vcpkg.json",
-                      "fileVersion":  "3.5.1",
+                      "fileVersion":  "3.5.2",
                       "productName":  "libffi: The portable foreign function interface library",
-                      "productVersion":  "3.5.1",
+                      "productVersion":  "3.5.2",
                       "copyright":  "Copyright (c) 1996-2024  Anthony Green, Red Hat, Inc and others."
                   },
                   {
                       "filename":  "bin/fontconfig-1.dll",
                       "fileDescription":  "Fontconfig",
                       "versionSource":  "ports/fontconfig/vcpkg.json",
-                      "fileVersion":  "2.15.0",
+                      "fileVersion":  "2.17.1",
                       "productName":  "Font configuration and customization library",
-                      "productVersion":  "2.15.0",
+                      "productVersion":  "2.17.1",
                       "copyright":  "Copyright (c) 2000-2020 Keith Packard, Patrick Lam and others"
                   },
                   {
@@ -113,72 +113,72 @@
                       "filename":  "bin/gio-2.0-0.dll",
                       "fileDescription":  "Gio",
                       "versionSource":  "ports/glib/vcpkg.json",
-                      "fileVersion":  "2.84.2",
+                      "fileVersion":  "2.86.3",
                       "productName":  "GLib",
-                      "productVersion":  "2.84.2",
+                      "productVersion":  "2.86.3",
                       "copyright":  "Copyright 2006-2011 Red Hat, Inc. and others."
                   },
                   {
                       "filename":  "bin/girepository-2.0-0.dll",
                       "fileDescription":  "GObject Introspection repository parser",
                       "versionSource":  "ports/glib/vcpkg.json",
-                      "fileVersion":  "2.84.2",
+                      "fileVersion":  "2.86.3",
                       "productName":  "GLib",
-                      "productVersion":  "2.84.2",
+                      "productVersion":  "2.86.3",
                       "copyright":  "Copyright (C) 2005-2025 Matthias Clasen, Red Hat, Inc. and others"
                   },
                   {
                       "filename":  "bin/glib-2.0-0.dll",
                       "fileDescription":  "GLib",
                       "versionSource":  "ports/glib/vcpkg.json",
-                      "fileVersion":  "2.84.2",
+                      "fileVersion":  "2.86.3",
                       "productName":  "GLib",
-                      "productVersion":  "2.84.2",
+                      "productVersion":  "2.86.3",
                       "copyright":  "Copyright 1995-2011 Peter Mattis, Spencer Kimball, Josh MacDonald and others."
                   },
                   {
                       "filename":  "bin/gmodule-2.0-0.dll",
                       "fileDescription":  "GModule",
                       "versionSource":  "ports/glib/vcpkg.json",
-                      "fileVersion":  "2.84.2",
+                      "fileVersion":  "2.86.3",
                       "productName":  "GLib",
-                      "productVersion":  "22.84.2",
+                      "productVersion":  "2.86.3",
                       "copyright":  "Copyright 1998-2011 Tim Janik and others."
                   },
                   {
                       "filename":  "bin/gobject-2.0-0.dll",
                       "fileDescription":  "GObject",
                       "versionSource":  "ports/glib/vcpkg.json",
-                      "fileVersion":  "2.84.2",
+                      "fileVersion":  "2.86.3",
                       "productName":  "GLib",
-                      "productVersion":  "2.84.2",
+                      "productVersion":  "2.86.3",
                       "copyright":  "Copyright 1998-2011 Tim Janik, Red Hat, Inc. and others"
                   },
                   {
                       "filename":  "bin/gthread-2.0-0.dll",
                       "fileDescription":  "GThread",
                       "versionSource":  "ports/glib/vcpkg.json",
-                      "fileVersion":  "2.84.2",
+                      "fileVersion":  "2.86.3",
                       "productName":  "GLib",
-                      "productVersion":  "2.84.2",
+                      "productVersion":  "2.86.3",
                       "copyright":  "Copyright 1995-2011 Peter Mattis, Spencer Kimball, Josh MacDonald, Sebastian Wilhelmi and others."
                   },
                   {
                       "filename":  "bin/harfbuzz-subset.dll",
                       "fileDescription":  "HarfBuzz font subsetter",
                       "versionSource":  "ports/harfbuzz/vcpkg.json",
-                      "fileVersion":  "10.2.0",
+                      "fileVersion":  "12.3.2",
                       "productName":  "Harfbuzz",
-                      "productVersion":  "10.2.0",
+                      "productVersion":  "12.3.2",
                       "copyright":  "Copyright © 2010-2022 Google, Inc. and others"
                   },
                   {
                       "filename":  "bin/harfbuzz.dll",
                       "fileDescription":  "HarfBuzz text shaping library",
                       "versionSource":  "ports/harfbuzz/vcpkg.json",
-                      "fileVersion":  "10.2.0",
+                      "fileVersion":  "12.3.2",
                       "productName":  "Harfbuzz",
-                      "productVersion":  "10.2.0",
+                      "productVersion":  "12.3.2",
                       "copyright":  "Copyright © 2010-2022 Google, Inc. and others"
                   },
                   {
@@ -203,54 +203,54 @@
                       "filename":  "bin/libexpat.dll",
                       "fileDescription":  "Expat XML parser",
                       "versionSource":  "ports/expat/vcpkg.json",
-                      "fileVersion":  "2.7.1",
+                      "fileVersion":  "2.7.4",
                       "productName":  "Expat",
-                      "productVersion":  "2.7.1",
+                      "productVersion":  "2.7.4",
                       "copyright":  "Copyright (c) 2001-2022 Expat maintainers"
                   },
                   {
                       "filename":  "bin/libpng16.dll",
                       "fileDescription":  "Loads and saves PNG files",
                       "versionSource":  "ports/libpng/vcpkg.json",
-                      "fileVersion":  "1.6.47",
+                      "fileVersion":  "1.6.54",
                       "productName":  "libpng",
-                      "productVersion":  "1.6.47",
+                      "productVersion":  "1.6.54",
                       "copyright":  "Copyright (c) 1995-2025 The PNG Reference Library Authors."
                   },
                   {
                       "filename":  "bin/pango-1.0-0.dll",
                       "fileDescription":  "Pango",
                       "versionSource":  "ports/pango/vcpkg.json",
-                      "fileVersion":  "1.56.1",
+                      "fileVersion":  "1.57.0",
                       "productName":  "Pango",
-                      "productVersion":  "1.56.1",
+                      "productVersion":  "1.57.0",
                       "copyright":  "Copyright 1999 Red Hat Software."
                   },
                   {
                       "filename":  "bin/pangocairo-1.0-0.dll",
                       "fileDescription":  "PangoCairo",
                       "versionSource":  "ports/pango/vcpkg.json",
-                      "fileVersion":  "1.56.1",
+                      "fileVersion":  "1.57.0",
                       "productName":  "PangoCairo",
-                      "productVersion":  "1.56.1",
+                      "productVersion":  "1.57.0",
                       "copyright":  "Copyright 2010 Red Hat Software."
                   },
                   {
                       "filename":  "bin/pangoft2-1.0-0.dll",
                       "fileDescription":  "PangoFT2",
                       "versionSource":  "ports/pango/vcpkg.json",
-                      "fileVersion":  "1.56.1",
+                      "fileVersion":  "1.57.0",
                       "productName":  "PangoFT2",
-                      "productVersion":  "1.56.1",
+                      "productVersion":  "1.57.0",
                       "copyright":  "Copyright 1999 Red Hat Software. Copyright 2000 Tor Lillqvist"
                   },
                   {
                       "filename":  "bin/pangowin32-1.0-0.dll",
                       "fileDescription":  "PangoWin32",
                       "versionSource":  "ports/pango/vcpkg.json",
-                      "fileVersion":  "1.56.1",
+                      "fileVersion":  "1.57.0",
                       "productName":  "PangoWin32",
-                      "productVersion":  "1.56.1",
+                      "productVersion":  "1.57.0",
                       "copyright":  "Copyright 1999 Red Hat Software. Copyright 2000 Tor Lillqvist"
                   },
                   {
@@ -284,18 +284,18 @@
                       "filename":  "bin/pcre2-posix.dll",
                       "fileDescription":  "Posix compatible interface to libpcre2-8",
                       "versionSource":  "ports/pcre2/vcpkg.json",
-                      "fileVersion":  "3.5.0",
+                      "fileVersion":  "10.47",
                       "productName":  "libpcre2-posix",
-                      "productVersion":  "3.5.0",
+                      "productVersion":  "10.47",
                       "copyright":  "Copyright (c) 1997-2024 University of Cambridge and others"
                   },
                   {
                       "filename":  "bin/pixman-1-0.dll",
                       "fileDescription":  "The pixman library (version 1)",
                       "versionSource":  "ports/pixman/vcpkg.json",
-                      "fileVersion":  "0.44.2",
+                      "fileVersion":  "0.46.4",
                       "productName":  "Pixman",
-                      "productVersion":  "0.44.2",
+                      "productVersion":  "0.46.4",
                       "copyright":  "Copyright (c) 1997-2010 Red Hat, Inc. and others"
                   },
                   {

--- a/custom-steps/pango/version-info.json
+++ b/custom-steps/pango/version-info.json
@@ -1,5 +1,5 @@
 {
-    "buildNumber":  101,
+    "buildNumber":  102,
     "files":  [
                   {
                       "filename":  "bin/brotlicommon.dll",

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -161,13 +161,13 @@
         "package": "pango",
         "linkType": "dynamic",
         "buildType": "release",
-        "vcpkgHash": "2025.06.13"
+        "vcpkgHash": "fb87e2bb3fe69e16c224989acb5a61349166c782"
       },
       "win": {
         "package": "pango",
         "linkType": "dynamic",
         "buildType": "release",
-        "vcpkgHash": "2025.06.13"
+        "vcpkgHash": "fb87e2bb3fe69e16c224989acb5a61349166c782"
       }
     },
     {

--- a/scripts/ps-modules/Build/Build.psm1
+++ b/scripts/ps-modules/Build/Build.psm1
@@ -528,8 +528,83 @@ function Resolve-Symlink {
    return $currentPath.FullName
 }
 
+function Apply-VcpkgPortPatch {
+    <#
+    .SYNOPSIS
+    Applies a patch file to a vcpkg port.
+    
+    .DESCRIPTION
+    Applies a git patch to a vcpkg port's files (typically portfile.cmake).
+    Useful for making TechSmith-specific modifications without maintaining
+    full custom port overlays.
+    
+    .PARAMETER PortName
+    The name of the vcpkg port to patch (e.g., "pango")
+    
+    .PARAMETER PatchFile
+    Path to the patch file to apply
+    
+    .PARAMETER WorkingDirectory
+    Optional. The directory to run git apply from. Defaults to the port directory.
+    
+    .EXAMPLE
+    Apply-VcpkgPortPatch -PortName "pango" -PatchFile "$PSScriptRoot/add-objc-support.patch"
+    #>
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$PortName,
+        
+        [Parameter(Mandatory=$true)]
+        [string]$PatchFile,
+        
+        [Parameter(Mandatory=$false)]
+        [string]$WorkingDirectory = $null
+    )
+    
+    $vcpkgPortDir = "$PSScriptRoot/../../../vcpkg/ports/$PortName"
+    
+    if (-not (Test-Path $vcpkgPortDir)) {
+        Write-Message "> vcpkg port directory not found: $vcpkgPortDir" -Warning
+        return $false
+    }
+    
+    if (-not (Test-Path $PatchFile)) {
+        Write-Message "> Patch file not found: $PatchFile" -Warning
+        return $false
+    }
+    
+    $workDir = if ($WorkingDirectory) { $WorkingDirectory } else { $vcpkgPortDir }
+    
+    Write-Message "> Applying patch to $PortName port: $(Split-Path -Leaf $PatchFile)"
+    
+    Push-Location $workDir
+    try {
+        $output = git apply --unidiff-zero --inaccurate-eof --ignore-space-change --ignore-whitespace --whitespace=nowarn "$PatchFile" 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            Write-Message "> Patch applied successfully"
+            return $true
+        } else {
+            # Check if patch is already applied
+            $checkOutput = git apply --reverse --check --ignore-whitespace "$PatchFile" 2>&1
+            if ($LASTEXITCODE -eq 0) {
+                Write-Message "> Patch appears to be already applied (skipping)"
+                return $true
+            } else {
+                Write-Message "> FAILED to apply patch to $PortName port" -Error
+                Write-Message "> Git apply exit code: $LASTEXITCODE" -Error
+                Write-Message "> Git apply output: $output" -Error
+                Write-Message "> Patch file: $PatchFile" -Error
+                Write-Message "> Working directory: $workDir" -Error
+                return $false
+            }
+        }
+    } finally {
+        Pop-Location
+    }
+}
+
 Export-ModuleMember -Function Get-PackageInfo, Run-WriteParamsStep, Run-SetupVcpkgStep, Run-PreBuildStep, Run-InstallCompilerIfNecessary, Run-InstallPackageStep, Run-PrestageAndFinalizeBuildArtifactsStep, Run-PostBuildStep, Run-StageBuildArtifactsStep, Run-StageSourceArtifactsStep, Run-CleanupStep, Get-Triplets
-Export-ModuleMember -Function NL, Write-Banner, Write-Message, Check-IsEmscriptenBuild, Get-PSObjectAsFormattedList, Get-IsOnMacOS, Get-IsOnWindowsOS, Get-IsOnLinux, Get-OSType, Get-VcPkgExe, Resolve-Symlink
+Export-ModuleMember -Function NL, Write-Banner, Write-Message, Check-IsEmscriptenBuild, Get-PSObjectAsFormattedList, Get-IsOnMacOS, Get-IsOnWindowsOS, Get-IsOnLinux, Get-OSType, Get-VcPkgExe, Resolve-Symlink, Apply-VcpkgPortPatch
 
 if ( (Get-IsOnMacOS) ) {
    Import-Module "$PSScriptRoot/../../ps-modules/MacBuild" -DisableNameChecking -Force

--- a/scripts/ps-modules/Util/Util.psm1
+++ b/scripts/ps-modules/Util/Util.psm1
@@ -97,6 +97,11 @@ param ($($paramArray -join ", "))
     }
 
     Invoke-Command -ScriptBlock $scriptBlock -ArgumentList $namedParams
+    
+    # Check if the script exited with an error code
+    if ($LASTEXITCODE -ne 0 -and $null -ne $LASTEXITCODE) {
+        throw "Script '$FilePath' exited with code $LASTEXITCODE"
+    }
 }
 
 function Write-Banner {


### PR DESCRIPTION
# Description
Update pango for expat 2.7.4
This is needed for this SnagitWin issue:
https://github.com/TechSmith/SnagitWin/issues/29334

It is a follow up of #108 

# Done
What I have done:
- mimic #87 to some extend
- verify that glib port in vcpkg fb87e2bb3fe69e16c224989acb5a61349166c782 included libexpat 2.7.4:
https://github.com/microsoft/vcpkg/tree/fb87e2bb3fe69e16c224989acb5a61349166c782/ports/expat
- checked out locally vcpkg: https://github.com/microsoft/vcpkg/tree/fb87e2bb3fe69e16c224989acb5a61349166c782
- created a script that would update all versions in version-info.json (full disclosure, this was mostly Copilot generated)
- update all the versions of all the ports from this hash by using the script
`C:\Projects\ThirdParty-Packages-vcpkg\custom-steps\pango\update-version-info.ps1 -VersionInfoPath C:\Projects\ThirdParty-Packages-vcpkg\custom-steps\pango\version-info.json -RootPath C:\Projects\_ThirdParties\vcpkg
Success: updated 34 entries and wrote to C:\Projects\ThirdParty-Packages-vcpkg\custom-steps\pango\version-info.json`

- verified it all sounded good: had to make an exception for pcre2 files which are using higher versions already, see https://github.com/TechSmith/ThirdParty-Packages-vcpkg/pull/108#discussion_r2762142316. See 182d6a1
- checkout out locally glib: https://github.com/GNOME/glib/releases/tag/2.86.3
   - verified that `tsc-allow-threadpriority-to-fail-windows.patch` still applies correctly

# Testing