### PR TITLE
Add onnxruntime port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ logs/
 _temp/
 /agent.md
 /progress.md
+staging/
+_private/

--- a/.pipelines/build-package-preconfigured.yml
+++ b/.pipelines/build-package-preconfigured.yml
@@ -24,6 +24,7 @@ parameters:
   - libzip-static
   - libzip-dynamic
   - minizip
+  - onnxruntime
   - openblas
   - openssl-static
   - opencv4

--- a/.pipelines/build-package-preconfigured.yml
+++ b/.pipelines/build-package-preconfigured.yml
@@ -12,6 +12,7 @@ parameters:
   values:
   - buildcache
   - dawn
+  - directx-headers
   - ffmpeg-cloud-gpl
   - ffmpeg-desktop-base
   - ffmpeg-desktop-hevc

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -21,4 +21,4 @@ if ($pkg -eq $null) {
 }
 
 Write-Message "$(NL)Running invoke-build.ps1...$(NL)"
-./invoke-build.ps1 -PackageName $PackageName -PackageAndFeatures $pkg.package -CustomTriplet $pkg.customTriplet -LinkType $pkg.linkType -BuildType $pkg.buildType -StagedArtifactsPath $StagedArtifactsPath -VcpkgHash $pkg.vcpkgHash -Publish $pkg.publish -ShowDebug:$ShowDebug
+./invoke-build.ps1 -PackageName $PackageName -PackageAndFeatures $pkg.package -CustomTriplets $pkg.customTriplets -LinkType $pkg.linkType -BuildType $pkg.buildType -StagedArtifactsPath $StagedArtifactsPath -VcpkgHash $pkg.vcpkgHash -Publish $pkg.publish -ShowDebug:$ShowDebug

--- a/custom-ports/directml/portfile.cmake
+++ b/custom-ports/directml/portfile.cmake
@@ -1,0 +1,70 @@
+# Download DirectML from NuGet package
+vcpkg_download_distfile(
+    ARCHIVE
+    URLS "https://www.nuget.org/api/v2/package/Microsoft.AI.DirectML/${VERSION}"
+    FILENAME "Microsoft.AI.DirectML.${VERSION}.nupkg"
+    SHA512 fde767f56904abc90fd53f65d8729c918ab7f6e3c5e1ecdd479908fc02b4535cf2b0860f7ab2acb9b731d6cb809b72c3d5d4d02853fb8f5ea022a47bc44ef285
+)
+
+# Extract the NuGet package (it's just a zip file)
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    NO_REMOVE_ONE_LEVEL
+)
+
+# Install headers
+file(INSTALL "${SOURCE_PATH}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include" FILES_MATCHING PATTERN "*.h")
+
+# Install libraries based on architecture
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    set(DML_ARCH_PATH "bin/x64-win")
+elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+    set(DML_ARCH_PATH "bin/x86-win")
+elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    set(DML_ARCH_PATH "bin/arm64-win")
+elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
+    set(DML_ARCH_PATH "bin/arm-win")
+else()
+    message(FATAL_ERROR "Unsupported architecture: ${VCPKG_TARGET_ARCHITECTURE}")
+endif()
+
+# Install DLLs and LIBs
+file(INSTALL "${SOURCE_PATH}/${DML_ARCH_PATH}/DirectML.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+file(INSTALL "${SOURCE_PATH}/${DML_ARCH_PATH}/DirectML.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+
+if(NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    file(INSTALL "${SOURCE_PATH}/${DML_ARCH_PATH}/DirectML.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+    file(INSTALL "${SOURCE_PATH}/${DML_ARCH_PATH}/DirectML.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+endif()
+
+# Create a simple CMake config file
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/DirectMLConfig.cmake" "
+include(CMakeFindDependencyMacro)
+
+if(NOT TARGET DirectML::DirectML)
+    add_library(DirectML::DirectML SHARED IMPORTED)
+    set_target_properties(DirectML::DirectML PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES \"\${CMAKE_CURRENT_LIST_DIR}/../../include\"
+    )
+    
+    if(EXISTS \"\${CMAKE_CURRENT_LIST_DIR}/../../bin/DirectML.dll\")
+        set_target_properties(DirectML::DirectML PROPERTIES
+            IMPORTED_LOCATION \"\${CMAKE_CURRENT_LIST_DIR}/../../bin/DirectML.dll\"
+            IMPORTED_IMPLIB \"\${CMAKE_CURRENT_LIST_DIR}/../../lib/DirectML.lib\"
+        )
+    endif()
+    
+    if(EXISTS \"\${CMAKE_CURRENT_LIST_DIR}/../../debug/bin/DirectML.dll\")
+        set_target_properties(DirectML::DirectML PROPERTIES
+            IMPORTED_LOCATION_DEBUG \"\${CMAKE_CURRENT_LIST_DIR}/../../debug/bin/DirectML.dll\"
+            IMPORTED_IMPLIB_DEBUG \"\${CMAKE_CURRENT_LIST_DIR}/../../debug/lib/DirectML.lib\"
+        )
+    endif()
+endif()
+
+set(DirectML_FOUND TRUE)
+")
+
+# Install copyright
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/custom-ports/directml/usage
+++ b/custom-ports/directml/usage
@@ -1,0 +1,4 @@
+directml provides CMake targets:
+
+    find_package(DirectML CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE DirectML::DirectML)

--- a/custom-ports/directml/vcpkg.json
+++ b/custom-ports/directml/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "directml",
+  "version": "1.15.4",
+  "description": "DirectML is a high-performance, hardware-accelerated DirectX 12 library for machine learning",
+  "homepage": "https://github.com/microsoft/DirectML",
+  "license": "MIT",
+  "supports": "windows",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/custom-ports/flatbuffers-onnxruntime/1001-tsc-disable-hardcoded-msvc-runtime-flags.patch
+++ b/custom-ports/flatbuffers-onnxruntime/1001-tsc-disable-hardcoded-msvc-runtime-flags.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f7f388f..4ab8149 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -456,12 +456,14 @@ if(FLATBUFFERS_BUILD_FLATC)
+   endif()
+ 
+   target_link_libraries(flatc PRIVATE $<BUILD_INTERFACE:ProjectConfig>)
++  if(FALSE) # DONT mess with runtime flags
+   target_compile_options(flatc
+     PRIVATE
+       $<$<AND:$<BOOL:${MSVC_LIKE}>,$<CONFIG:Release>>:
+         /MT
+       >
+   )
++  endif()
+ 
+   if(FLATBUFFERS_CODE_SANITIZE AND NOT WIN32)
+     add_fsanitize_to_target(flatc ${FLATBUFFERS_CODE_SANITIZE})

--- a/custom-ports/flatbuffers-onnxruntime/fix-uwp-build.patch
+++ b/custom-ports/flatbuffers-onnxruntime/fix-uwp-build.patch
@@ -1,0 +1,20 @@
+diff --git a/src/util.cpp b/src/util.cpp
+index aabc23a..06e9ebe 100644
+--- a/src/util.cpp
++++ b/src/util.cpp
+@@ -420,9 +420,15 @@ bool ReadEnvironmentVariable(const char *var_name, std::string *_value) {
+ #ifdef _MSC_VER
+   __pragma(warning(disable : 4996));  // _CRT_SECURE_NO_WARNINGS
+ #endif
++#if _WIN32_WINNT < 0x0A00
+   auto env_str = std::getenv(var_name);
+   if (!env_str) return false;
+   if (_value) *_value = std::string(env_str);
++#else
++  //There is no support for environment variables in UWP
++  var_name; // Do nothing
++  *_value = std::string("");
++#endif
+   return true;
+ }
+ 

--- a/custom-ports/flatbuffers-onnxruntime/portfile.cmake
+++ b/custom-ports/flatbuffers-onnxruntime/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-uwp-build.patch
+        1001-tsc-disable-hardcoded-msvc-runtime-flags.patch
 )
 
 set(options "")

--- a/custom-ports/flatbuffers-onnxruntime/portfile.cmake
+++ b/custom-ports/flatbuffers-onnxruntime/portfile.cmake
@@ -1,0 +1,49 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO google/flatbuffers
+    REF "v${VERSION}"
+    SHA512 cd0a5efad8016e1217d01a181d6b02e546f5693c6412361bfeaee820d5dfe5e2a424cee1963270e851c1a4f936ae8a0032a51c5bb16ee19313e0ecc77dc4ba31
+    HEAD_REF master
+    PATCHES
+        fix-uwp-build.patch
+)
+
+set(options "")
+if(VCPKG_CROSSCOMPILING)
+    list(APPEND options -DFLATBUFFERS_BUILD_FLATC=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF)
+    if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
+        # The option may cause "#error Unsupported architecture"
+        list(APPEND options -DFLATBUFFERS_OSX_BUILD_UNIVERSAL=OFF)
+    endif()
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DFLATBUFFERS_BUILD_TESTS=OFF
+        -DFLATBUFFERS_BUILD_GRPCTEST=OFF
+        ${options}
+    OPTIONS_DEBUG
+        -DFLATBUFFERS_BUILD_FLATC=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/flatbuffers)
+vcpkg_fixup_pkgconfig()
+
+file(GLOB flatc_path ${CURRENT_PACKAGES_DIR}/bin/flatc*)
+if(flatc_path)
+    vcpkg_copy_tools(TOOL_NAMES flatc AUTO_CLEAN)
+else()
+    file(APPEND "${CURRENT_PACKAGES_DIR}/share/flatbuffers-onnxruntime/flatbuffers-config.cmake"
+"\ninclude(\"\${CMAKE_CURRENT_LIST_DIR}/../../../${HOST_TRIPLET}/share/flatbuffers-onnxruntime/FlatcTargets.cmake\")\n")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/flatbuffers/pch")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/custom-ports/flatbuffers-onnxruntime/vcpkg.json
+++ b/custom-ports/flatbuffers-onnxruntime/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "flatbuffers-onnxruntime",
+  "version": "23.5.26",
+  "port-version": 1,
+  "description": "FlatBuffers is a cross platform serialization library architected for maximum memory efficiency. It allows you to directly access serialized data without parsing/unpacking it first, while still having great forwards/backwards compatibility.",
+  "homepage": "https://google.github.io/flatbuffers/",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "flatbuffers-onnxruntime",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/custom-ports/onnxruntime/1001-tsc-fix-coreml.patch
+++ b/custom-ports/onnxruntime/1001-tsc-fix-coreml.patch
@@ -1,0 +1,30 @@
+diff --git a/cmake/onnxruntime_providers_coreml.cmake b/cmake/onnxruntime_providers_coreml.cmake
+index 0000000..1111111 100644
+--- a/cmake/onnxruntime_providers_coreml.cmake
++++ b/cmake/onnxruntime_providers_coreml.cmake
+@@ -19,8 +19,25 @@ if(LINUX)
+   endif()
+ endif()
+ 
++if(onnxruntime_USE_VCPKG)
++  # When using vcpkg, download coremltools to get proto files
++  include(FetchContent)
++  FetchContent_Declare(
++    coremltools
++    URL https://github.com/apple/coremltools/archive/refs/tags/7.1.zip
++    URL_HASH SHA1=f1bab0f30966f2e217d8e01207d518f230a1641a
++  )
++  FetchContent_GetProperties(coremltools)
++  if(NOT coremltools_POPULATED)
++    FetchContent_Populate(coremltools)
++  endif()
++  set(COREML_PROTO_ROOT ${coremltools_SOURCE_DIR}/mlmodel/format)
++else()
+ # Compile CoreML proto definition to ${CMAKE_CURRENT_BINARY_DIR}/coreml_proto
+ set(COREML_PROTO_ROOT ${coremltools_SOURCE_DIR}/mlmodel/format)
++endif()
++
++# Common proto compilation for both vcpkg and non-vcpkg builds
+ file(GLOB coreml_proto_srcs "${COREML_PROTO_ROOT}/*.proto")
+ 
+ onnxruntime_add_static_library(coreml_proto ${coreml_proto_srcs})

--- a/custom-ports/onnxruntime/1002-tsc-fix-winml-wcos-check.patch
+++ b/custom-ports/onnxruntime/1002-tsc-fix-winml-wcos-check.patch
@@ -1,0 +1,20 @@
+diff --git a/cmake/winml.cmake b/cmake/winml.cmake
+index f2651d0..0215e62 100644
+--- a/cmake/winml.cmake
++++ b/cmake/winml.cmake
+@@ -1,9 +1,12 @@
+ # Copyright (c) Microsoft Corporation. All rights reserved.
+ # Licensed under the MIT License.
+ 
+-if (CMAKE_CXX_STANDARD_LIBRARIES MATCHES kernel32.lib)
+-  message(FATAL_ERROR "WinML is only supported on WCOS")
+-endif()
++# TechSmith patch: Remove obsolete WCOS-only check. WCOS was an abandoned Microsoft
++# internal project. WinML works fine on standard Windows 10/11 with DirectML.
++# Original check incorrectly rejected standard Windows builds:
++#   if (CMAKE_CXX_STANDARD_LIBRARIES MATCHES kernel32.lib)
++#     message(FATAL_ERROR "WinML is only supported on WCOS")
++#   endif()
+ 
+ include(precompiled_header.cmake)
+ include(target_delayload.cmake)

--- a/custom-ports/onnxruntime/fix-cmake-cuda.patch
+++ b/custom-ports/onnxruntime/fix-cmake-cuda.patch
@@ -1,0 +1,46 @@
+diff --git a/cmake/external/cuDNN.cmake b/cmake/external/cuDNN.cmake
+index b428ccb..9b73acb 100644
+--- a/cmake/external/cuDNN.cmake
++++ b/cmake/external/cuDNN.cmake
+@@ -1,3 +1,5 @@
++find_package(CUDNN REQUIRED) # vcpkg port 'cudnn'
++get_filename_component(cudnn_LIBRARY "${CUDNN_LIBRARY}" ABSOLUTE)
+ add_library(CUDNN::cudnn_all INTERFACE IMPORTED)
+ 
+ find_path(
+diff --git a/cmake/external/cudnn_frontend.cmake b/cmake/external/cudnn_frontend.cmake
+index d89ab0f..c28568f 100644
+--- a/cmake/external/cudnn_frontend.cmake
++++ b/cmake/external/cudnn_frontend.cmake
+@@ -1,4 +1,5 @@
+-
++find_package(cudnn_frontend CONFIG REQUIRED) # cudnn-frontend 1.13.0+
++return()
+ onnxruntime_fetchcontent_declare(
+   cudnn_frontend
+   URL ${DEP_URL_cudnn_frontend}
+diff --git a/cmake/onnxruntime_providers_cuda.cmake b/cmake/onnxruntime_providers_cuda.cmake
+index 91707c4..243783b 100644
+--- a/cmake/onnxruntime_providers_cuda.cmake
++++ b/cmake/onnxruntime_providers_cuda.cmake
+@@ -149,6 +149,9 @@
+     onnxruntime_add_shared_library_module(onnxruntime_providers_cuda ${onnxruntime_providers_cuda_all_srcs})
+   endif()
+ 
++  if(MSVC)
++    target_compile_options(onnxruntime_providers_cuda PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/bigobj>)
++  endif()
+   if(WIN32)
+     # FILE_NAME preprocessor definition is used in onnxruntime_providers_cuda.rc
+     target_compile_definitions(onnxruntime_providers_cuda PRIVATE FILE_NAME=\"onnxruntime_providers_cuda.dll\")
+@@ -241,8 +244,8 @@
+               ${ABSEIL_LIBS} ${ONNXRUNTIME_PROVIDERS_SHARED} Boost::mp11 safeint_interface)
+     endif()
+ 
+-    include(cutlass)
+-    target_include_directories(${target} PRIVATE ${cutlass_SOURCE_DIR}/include ${cutlass_SOURCE_DIR}/examples ${cutlass_SOURCE_DIR}/tools/util/include)
++    find_package(NvidiaCutlass REQUIRED)
++    target_link_libraries(${target} PRIVATE nvidia::cutlass::cutlass nvidia::cutlass::tools::util)
+     target_link_libraries(${target} PRIVATE Eigen3::Eigen)
+     target_include_directories(${target} PRIVATE ${ONNXRUNTIME_ROOT} ${CMAKE_CURRENT_BINARY_DIR} PUBLIC ${CUDAToolkit_INCLUDE_DIRS})
+     # ${CMAKE_CURRENT_BINARY_DIR} is so that #include "onnxruntime_config.h" inside tensor_shape.h is found

--- a/custom-ports/onnxruntime/fix-cmake.patch
+++ b/custom-ports/onnxruntime/fix-cmake.patch
@@ -1,0 +1,37 @@
+diff --git a/cmake/onnxruntime_framework.cmake b/cmake/onnxruntime_framework.cmake
+index 15f3105..af6609b 100644
+--- a/cmake/onnxruntime_framework.cmake
++++ b/cmake/onnxruntime_framework.cmake
+@@ -122,5 +122,5 @@ else()
+             ARCHIVE   DESTINATION ${CMAKE_INSTALL_LIBDIR}
+             LIBRARY   DESTINATION ${CMAKE_INSTALL_LIBDIR}
+             RUNTIME   DESTINATION ${CMAKE_INSTALL_BINDIR}
+-            FRAMEWORK DESTINATION ${CMAKE_INSTALL_BINDIR})
++            FRAMEWORK DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ endif()
+diff --git a/cmake/external/abseil-cpp.cmake b/cmake/external/abseil-cpp.cmake
+index eede60a..07f5f77 100644
+--- a/cmake/external/abseil-cpp.cmake
++++ b/cmake/external/abseil-cpp.cmake
+@@ -122,7 +122,7 @@ absl::absl_check
+ absl::hash_function_defaults
+ absl::function_ref
+ absl::city
+-absl::low_level_hash
++# absl::low_level_hash # abseil 20250814.1+
+ absl::fixed_array
+ absl::variant
+ absl::meta
+diff --git a/cmake/onnxruntime_webassembly.cmake b/cmake/onnxruntime_webassembly.cmake
+index ffe8661..a3e9b4f 100644
+--- a/cmake/onnxruntime_webassembly.cmake
++++ b/cmake/onnxruntime_webassembly.cmake
+@@ -94,7 +94,7 @@ if (NOT onnxruntime_ENABLE_WEBASSEMBLY_THREADS)
+   )
+ 
+   # Override re2 compiler options to remove -pthread
+-  set_property(TARGET re2 PROPERTY COMPILE_OPTIONS )
++  # set_property(TARGET re2 PROPERTY COMPILE_OPTIONS )
+ endif()
+ 
+ if (NOT onnxruntime_USE_VCPKG)

--- a/custom-ports/onnxruntime/portfile.cmake
+++ b/custom-ports/onnxruntime/portfile.cmake
@@ -1,0 +1,160 @@
+# https://github.com/microsoft/onnxruntime/blob/v1.22.1/tools/python/util/vcpkg_helpers.py
+message(WARNING "The port requires 'onnx' port build with CMake option ONNX_DISABLE_STATIC_REGISTRATION=ON")
+if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
+    if("framework" IN_LIST FEATURES)
+        # The Objective-C API requires onnxruntime_BUILD_SHARED_LIB
+        vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+    endif()
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO microsoft/onnxruntime
+    REF "v${VERSION}"
+    SHA512 373c51575ada457b8aead5d195a5f3eba62fb747b6370a2a9889fff875c40ea30af8fd49104d58cc86f79247410e829086b0979f37ca8635c6dd34960e9cc424
+    PATCHES
+        fix-cmake.patch # .framework install, external library workarounds(abseil-cpp, eigen3)
+        fix-cmake-cuda.patch
+)
+
+find_program(PROTOC NAMES protoc PATHS "${CURRENT_HOST_INSTALLED_DIR}/tools/protobuf" REQUIRED NO_DEFAULT_PATH NO_CMAKE_PATH)
+message(STATUS "Using protoc: ${PROTOC}")
+
+find_program(FLATC NAMES flatc PATHS "${CURRENT_HOST_INSTALLED_DIR}/tools/flatbuffers" REQUIRED NO_DEFAULT_PATH NO_CMAKE_PATH)
+message(STATUS "Using flatc: ${FLATC}")
+
+vcpkg_find_acquire_program(PYTHON3)
+get_filename_component(PYTHON_PATH "${PYTHON3}" PATH)
+message(STATUS "Using python3: ${PYTHON3}")
+
+vcpkg_execute_required_process(
+    COMMAND "${PYTHON3}" onnxruntime/core/flatbuffers/schema/compile_schema.py --flatc "${FLATC}"
+    LOGNAME compile_schema_core
+    WORKING_DIRECTORY "${SOURCE_PATH}"
+)
+vcpkg_execute_required_process(
+    COMMAND "${PYTHON3}" onnxruntime/lora/adapter_format/compile_schema.py --flatc "${FLATC}"
+    LOGNAME compile_schema_lora
+    WORKING_DIRECTORY "${SOURCE_PATH}"
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        python    onnxruntime_ENABLE_PYTHON
+        training  onnxruntime_ENABLE_TRAINING
+        training  onnxruntime_ENABLE_TRAINING_APIS
+        cuda      onnxruntime_USE_CUDA
+        cuda      onnxruntime_USE_CUDA_NHWC_OPS
+        openvino  onnxruntime_USE_OPENVINO
+        tensorrt  onnxruntime_USE_TENSORRT
+        tensorrt  onnxruntime_USE_TENSORRT_BUILTIN_PARSER
+        directml  onnxruntime_USE_DML
+        directml  onnxruntime_USE_CUSTOM_DIRECTML
+        winml     onnxruntime_USE_WINML
+        coreml    onnxruntime_USE_COREML
+        mimalloc  onnxruntime_USE_MIMALLOC
+        valgrind  onnxruntime_USE_VALGRIND
+        xnnpack   onnxruntime_USE_XNNPACK
+        nnapi     onnxruntime_USE_NNAPI_BUILTIN
+        azure     onnxruntime_USE_AZURE
+        test      onnxruntime_BUILD_UNIT_TESTS
+        test      onnxruntime_BUILD_BENCHMARKS
+        test      onnxruntime_RUN_ONNX_TESTS
+        framework onnxruntime_BUILD_APPLE_FRAMEWORK
+        framework onnxruntime_BUILD_OBJC
+        nccl      onnxruntime_USE_NCCL
+    INVERTED_FEATURES
+        cuda      onnxruntime_USE_MEMORY_EFFICIENT_ATTENTION
+)
+
+if("cuda" IN_LIST FEATURES)
+    vcpkg_find_cuda(OUT_CUDA_TOOLKIT_ROOT cuda_toolkit_root)
+    list(APPEND FEATURE_OPTIONS
+        "-DCMAKE_CUDA_COMPILER=${NVCC}"
+        "-DCUDAToolkit_ROOT=${cuda_toolkit_root}"
+        # "-DCMAKE_CUDA_ARCHITECTURES=native"
+        # too much warnings about attribute
+        "-DCMAKE_CUDA_FLAGS=-Xcudafe --diag_suppress=2803 -Wno-deprecated-gpu-targets"
+    )
+endif()
+
+if("tensorrt" IN_LIST FEATURES)
+    if(DEFINED ENV{TENSORRT_HOME})
+        set(TENSORRT_HOME "$ENV{TENSORRT_HOME}")
+    endif()
+    if(DEFINED TENSORRT_HOME)
+        message(STATUS "Using TensorRT: ${TENSORRT_HOME}")
+        list(APPEND FEATURE_OPTIONS "-Donnxruntime_TENSORRT_HOME:PATH=${TENSORRT_HOME}")
+    else()
+        message(WARNING "Define TENSORRT_HOME for onnxruntime_TENSORRT_HOME")
+    endif()
+endif()
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
+
+# see tools/ci_build/build.py
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/cmake"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        "-DPython_EXECUTABLE:FILEPATH=${PYTHON3}"
+        "-DProtobuf_PROTOC_EXECUTABLE:FILEPATH=${PROTOC}"
+        "-DONNX_CUSTOM_PROTOC_EXECUTABLE:FILEPATH=${PROTOC}"
+        -DBUILD_PKGCONFIG_FILES=ON
+        -Donnxruntime_BUILD_SHARED_LIB=${BUILD_SHARED}
+        -Donnxruntime_CROSS_COMPILING=${VCPKG_CROSSCOMPILING}
+        -Donnxruntime_USE_EXTENSIONS=OFF
+        -Donnxruntime_USE_NNAPI_BUILTIN=${VCPKG_TARGET_IS_ANDROID}
+        -Donnxruntime_USE_VCPKG=ON
+        -Donnxruntime_ENABLE_CPUINFO=ON
+        -Donnxruntime_ENABLE_MICROSOFT_INTERNAL=OFF
+        -Donnxruntime_ENABLE_BITCODE=OFF
+        -Donnxruntime_ENABLE_PYTHON=OFF
+        -Donnxruntime_ENABLE_EXTERNAL_CUSTOM_OP_SCHEMAS=OFF
+        -Donnxruntime_ENABLE_MEMORY_PROFILE=OFF
+        -Donnxruntime_ENABLE_LAZY_TENSOR=OFF
+        -Donnxruntime_DISABLE_RTTI=OFF
+        -Donnxruntime_DISABLE_ABSEIL=OFF
+        # some other customizations ...
+        --compile-no-warning-as-error
+    OPTIONS_DEBUG
+        -Donnxruntime_ENABLE_MEMLEAK_CHECKER=OFF
+        -Donnxruntime_DEBUG_NODE_INPUTS_OUTPUTS=1
+    MAYBE_UNUSED_VARIABLES
+        Python_EXECUTABLE
+        onnxruntime_TENSORRT_PLACEHOLDER_BUILDER
+        onnxruntime_NVCC_THREADS
+        CMAKE_CUDA_FLAGS
+        onnxruntime_USE_CUSTOM_DIRECTML
+)
+if("cuda" IN_LIST FEATURES)
+    vcpkg_cmake_build(TARGET onnxruntime_providers_cuda LOGFILE_BASE build-cuda)
+endif()
+if("tensorrt" IN_LIST FEATURES)
+    vcpkg_cmake_build(TARGET onnxruntime_providers_tensorrt LOGFILE_BASE build-tensorrt)
+endif()
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/onnxruntime)
+vcpkg_fixup_pkgconfig() # pkg_check_modules(libonnxruntime)
+
+# relocates the onnxruntime_providers_* binaries before vcpkg_copy_pdbs()
+function(reolocate_ort_providers)
+    if(VCPKG_TARGET_IS_WINDOWS AND (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic"))
+        # the target is expected to be used without the .lib files
+        file(GLOB PROVIDE_BINS_DBG  "${CURRENT_PACKAGES_DIR}/debug/lib/onnxruntime_providers_*.dll")
+        file(COPY ${PROVIDE_BINS_DBG} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+        file(GLOB PROVIDE_BINS_REL "${CURRENT_PACKAGES_DIR}/lib/onnxruntime_providers_*.dll")
+        file(COPY ${PROVIDE_BINS_REL} DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+        file(REMOVE ${PROVIDE_BINS_DBG} ${PROVIDE_BINS_REL})
+    endif()
+endfunction()
+
+reolocate_ort_providers()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin" "${CURRENT_PACKAGES_DIR}/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/custom-ports/onnxruntime/portfile.cmake
+++ b/custom-ports/onnxruntime/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_from_github(
         fix-cmake.patch # .framework install, external library workarounds(abseil-cpp, eigen3)
         fix-cmake-cuda.patch
         1001-tsc-fix-coreml.patch # Fix CoreML proto file handling when using vcpkg
+        1002-tsc-fix-winml-wcos-check.patch # Remove obsolete WCOS-only check that blocks WinML on standard Windows
 )
 
 find_program(PROTOC NAMES protoc PATHS "${CURRENT_HOST_INSTALLED_DIR}/tools/protobuf" REQUIRED NO_DEFAULT_PATH NO_CMAKE_PATH)

--- a/custom-ports/onnxruntime/portfile.cmake
+++ b/custom-ports/onnxruntime/portfile.cmake
@@ -142,6 +142,12 @@ if("coreml" IN_LIST FEATURES)
     list(APPEND FEATURE_OPTIONS "-DFETCHCONTENT_SOURCE_DIR_PSIMD=${PSIMD_SOURCE}")
 endif()
 
+# Add WindowsApp.lib for WinML builds on Windows to provide WinRT exception functions
+set(WINML_LINKER_FLAGS "")
+if(VCPKG_TARGET_IS_WINDOWS AND "winml" IN_LIST FEATURES)
+    set(WINML_LINKER_FLAGS "/DEFAULTLIB:WindowsApp.lib")
+endif()
+
 # see tools/ci_build/build.py
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/cmake"
@@ -166,6 +172,7 @@ vcpkg_cmake_configure(
         -Donnxruntime_DISABLE_RTTI=OFF
         -Donnxruntime_DISABLE_ABSEIL=OFF
         -Donnxruntime_PARALLEL_COMPILE=ON
+        "-DCMAKE_SHARED_LINKER_FLAGS=${WINML_LINKER_FLAGS}"
         # some other customizations ...
         --compile-no-warning-as-error
     OPTIONS_DEBUG
@@ -178,6 +185,7 @@ vcpkg_cmake_configure(
         CMAKE_CUDA_FLAGS
         onnxruntime_USE_CUSTOM_DIRECTML
         onnxruntime_PARALLEL_COMPILE
+        CMAKE_SHARED_LINKER_FLAGS
 )
 if("cuda" IN_LIST FEATURES)
     vcpkg_cmake_build(TARGET onnxruntime_providers_cuda LOGFILE_BASE build-cuda)

--- a/custom-ports/onnxruntime/portfile.cmake
+++ b/custom-ports/onnxruntime/portfile.cmake
@@ -20,7 +20,7 @@ vcpkg_from_github(
 find_program(PROTOC NAMES protoc PATHS "${CURRENT_HOST_INSTALLED_DIR}/tools/protobuf" REQUIRED NO_DEFAULT_PATH NO_CMAKE_PATH)
 message(STATUS "Using protoc: ${PROTOC}")
 
-find_program(FLATC NAMES flatc PATHS "${CURRENT_HOST_INSTALLED_DIR}/tools/flatbuffers" REQUIRED NO_DEFAULT_PATH NO_CMAKE_PATH)
+find_program(FLATC NAMES flatc PATHS "${CURRENT_HOST_INSTALLED_DIR}/tools/flatbuffers-onnxruntime" REQUIRED NO_DEFAULT_PATH NO_CMAKE_PATH)
 message(STATUS "Using flatc: ${FLATC}")
 
 vcpkg_find_acquire_program(PYTHON3)

--- a/custom-ports/onnxruntime/portfile.cmake
+++ b/custom-ports/onnxruntime/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_from_github(
     PATCHES
         fix-cmake.patch # .framework install, external library workarounds(abseil-cpp, eigen3)
         fix-cmake-cuda.patch
+        1001-tsc-fix-coreml.patch # Fix CoreML proto file handling when using vcpkg
 )
 
 find_program(PROTOC NAMES protoc PATHS "${CURRENT_HOST_INSTALLED_DIR}/tools/protobuf" REQUIRED NO_DEFAULT_PATH NO_CMAKE_PATH)
@@ -43,6 +44,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         python    onnxruntime_ENABLE_PYTHON
         training  onnxruntime_ENABLE_TRAINING
         training  onnxruntime_ENABLE_TRAINING_APIS
+        training  onnxruntime_ENABLE_TRAINING_OPS
         cuda      onnxruntime_USE_CUDA
         cuda      onnxruntime_USE_CUDA_NHWC_OPS
         openvino  onnxruntime_USE_OPENVINO
@@ -63,6 +65,16 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         framework onnxruntime_BUILD_APPLE_FRAMEWORK
         framework onnxruntime_BUILD_OBJC
         nccl      onnxruntime_USE_NCCL
+        dnnl      onnxruntime_USE_DNNL
+        qnn       onnxruntime_USE_QNN
+        snpe      onnxruntime_USE_SNPE
+        rknpu     onnxruntime_USE_RKNPU
+        vsinpu    onnxruntime_USE_VSINPU
+        vitisai   onnxruntime_USE_VITISAI
+        migraphx  onnxruntime_USE_MIGRAPHX
+        cann      onnxruntime_USE_CANN
+        webnn     onnxruntime_USE_WEBNN
+        telemetry onnxruntime_USE_TELEMETRY
     INVERTED_FEATURES
         cuda      onnxruntime_USE_MEMORY_EFFICIENT_ATTENTION
 )
@@ -92,6 +104,43 @@ endif()
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
 
+# Pre-download dependencies for CoreML EP (needed because vcpkg sets FETCHCONTENT_FULLY_DISCONNECTED=ON
+# which blocks FetchContent downloads at configure time)
+if("coreml" IN_LIST FEATURES)
+    # coremltools: provides .proto files for CoreML model format
+    vcpkg_download_distfile(COREMLTOOLS_ARCHIVE
+        URLS "https://github.com/apple/coremltools/archive/refs/tags/7.1.tar.gz"
+        FILENAME "apple-coremltools-7.1.tar.gz"
+        SHA512 64a8f9f9a47266d58b5c19fb7ad21458a481ea7d11309bd46ffc3390771f70c7ccb958abfdeedad86e7785fe320d532928441cc120d0e3570e96d149ec458b72
+    )
+    vcpkg_extract_source_archive(COREMLTOOLS_SOURCE
+        ARCHIVE "${COREMLTOOLS_ARCHIVE}"
+    )
+    list(APPEND FEATURE_OPTIONS "-DFETCHCONTENT_SOURCE_DIR_COREMLTOOLS=${COREMLTOOLS_SOURCE}")
+
+    # fp16: half-precision floating point conversion (used by coremltools MILBlob)
+    vcpkg_download_distfile(FP16_ARCHIVE
+        URLS "https://github.com/Maratyszcza/FP16/archive/0a92994d729ff76a58f692d3028ca1b64b145d91.zip"
+        FILENAME "maratyszcza-fp16-0a92994d.zip"
+        SHA512 f7f61c40e13128068f1ee10e6273ed2ebe626a89b3eebbe8d479ae7ab346119404ea0c2a7caa80ea441d80b8ca9c5bd8acffb79fb3499c38f50bb52ebe441efe
+    )
+    vcpkg_extract_source_archive(FP16_SOURCE
+        ARCHIVE "${FP16_ARCHIVE}"
+    )
+    list(APPEND FEATURE_OPTIONS "-DFETCHCONTENT_SOURCE_DIR_FP16=${FP16_SOURCE}")
+
+    # psimd: portable SIMD intrinsics (dependency of fp16)
+    vcpkg_download_distfile(PSIMD_ARCHIVE
+        URLS "https://github.com/Maratyszcza/psimd/archive/072586a71b55b7f8c584153d223e95687148a900.zip"
+        FILENAME "maratyszcza-psimd-072586a7.zip"
+        SHA512 98c9e13f1e79db84289f48f1e1699852a54d3a7f1b07144008c67cf73c8b4487e9647755f6fe2a2d519419d669248b37a85d8aa3f6ad2f8fdf8e97d2de7ed7c4
+    )
+    vcpkg_extract_source_archive(PSIMD_SOURCE
+        ARCHIVE "${PSIMD_ARCHIVE}"
+    )
+    list(APPEND FEATURE_OPTIONS "-DFETCHCONTENT_SOURCE_DIR_PSIMD=${PSIMD_SOURCE}")
+endif()
+
 # see tools/ci_build/build.py
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/cmake"
@@ -115,6 +164,7 @@ vcpkg_cmake_configure(
         -Donnxruntime_ENABLE_LAZY_TENSOR=OFF
         -Donnxruntime_DISABLE_RTTI=OFF
         -Donnxruntime_DISABLE_ABSEIL=OFF
+        -Donnxruntime_PARALLEL_COMPILE=ON
         # some other customizations ...
         --compile-no-warning-as-error
     OPTIONS_DEBUG
@@ -126,6 +176,7 @@ vcpkg_cmake_configure(
         onnxruntime_NVCC_THREADS
         CMAKE_CUDA_FLAGS
         onnxruntime_USE_CUSTOM_DIRECTML
+        onnxruntime_PARALLEL_COMPILE
 )
 if("cuda" IN_LIST FEATURES)
     vcpkg_cmake_build(TARGET onnxruntime_providers_cuda LOGFILE_BASE build-cuda)

--- a/custom-ports/onnxruntime/vcpkg.json
+++ b/custom-ports/onnxruntime/vcpkg.json
@@ -1,0 +1,110 @@
+{
+  "name": "onnxruntime",
+  "version-semver": "1.23.2",
+  "description": "ONNX Runtime: cross-platform, high performance ML inferencing and training accelerator",
+  "homepage": "https://github.com/microsoft/onnxruntime",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "abseil",
+      "version>=": "20250512.1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.82.0"
+    },
+    {
+      "name": "boost-mp11",
+      "version>=": "1.82.0"
+    },
+    "cpuinfo",
+    "cxxopts",
+    "date",
+    "dlpack",
+    "eigen3",
+    {
+      "name": "flatbuffers",
+      "host": true,
+      "version>=": "23.5.26"
+    },
+    {
+      "name": "flatbuffers",
+      "version>=": "23.5.26"
+    },
+    "ms-gsl",
+    "nlohmann-json",
+    {
+      "name": "onnx",
+      "version>=": "1.19.0"
+    },
+    "optional-lite",
+    {
+      "name": "protobuf",
+      "version>=": "3.21.12"
+    },
+    {
+      "name": "protobuf",
+      "host": true,
+      "version>=": "3.21.12"
+    },
+    "re2",
+    "safeint",
+    "utf8-range",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "wil",
+      "platform": "windows"
+    }
+  ],
+  "features": {
+    "cuda": {
+      "description": "Build with CUDA support",
+      "supports": "(x64 & windows & !static) | (x64 & linux)",
+      "dependencies": [
+        "cuda",
+        "cudnn",
+        "cudnn-frontend",
+        "nvidia-cutlass"
+      ]
+    },
+    "framework": {
+      "description": "Build a macOS/iOS framework, Objective-C library",
+      "supports": "osx | ios"
+    },
+    "openvino": {
+      "description": "Build with OpenVINO support",
+      "supports": "!(osx | ios | android | emscripten)",
+      "dependencies": [
+        {
+          "name": "openvino",
+          "default-features": false,
+          "features": [
+            "cpu",
+            "gpu",
+            "onnx"
+          ]
+        }
+      ]
+    },
+    "tensorrt": {
+      "description": "Build with TensorRT support",
+      "dependencies": [
+        {
+          "name": "onnxruntime",
+          "default-features": false,
+          "features": [
+            "cuda"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/custom-ports/onnxruntime/vcpkg.json
+++ b/custom-ports/onnxruntime/vcpkg.json
@@ -19,6 +19,10 @@
       "platform": "windows"
     },
     {
+      "name": "winml",
+      "platform": "windows"
+    },
+    {
       "name": "coreml",
       "platform": "osx | ios"
     }

--- a/custom-ports/onnxruntime/vcpkg.json
+++ b/custom-ports/onnxruntime/vcpkg.json
@@ -24,14 +24,10 @@
     "dlpack",
     "eigen3",
     {
-      "name": "flatbuffers",
-      "host": true,
-      "version>=": "23.5.26"
+      "name": "flatbuffers-onnxruntime",
+      "host": true
     },
-    {
-      "name": "flatbuffers",
-      "version>=": "23.5.26"
-    },
+    "flatbuffers-onnxruntime",
     "ms-gsl",
     "nlohmann-json",
     {

--- a/custom-ports/onnxruntime/vcpkg.json
+++ b/custom-ports/onnxruntime/vcpkg.json
@@ -5,6 +5,24 @@
   "homepage": "https://github.com/microsoft/onnxruntime",
   "license": "MIT",
   "supports": "!uwp",
+  "default-features": [
+    {
+      "name": "directml",
+      "platform": "windows"
+    },
+    {
+      "name": "directx-headers",
+      "platform": "windows"
+    },
+    {
+      "name": "cppwinrt",
+      "platform": "windows"
+    },
+    {
+      "name": "coreml",
+      "platform": "osx | ios"
+    }
+  ],
   "dependencies": [
     {
       "name": "abseil",
@@ -61,6 +79,24 @@
     }
   ],
   "features": {
+    "azure": {
+      "description": "Build with Azure execution provider support"
+    },
+    "cann": {
+      "description": "Build with CANN execution provider (Huawei Ascend)",
+      "supports": "linux"
+    },
+    "coreml": {
+      "description": "Build with CoreML execution provider (macOS/iOS only)",
+      "supports": "osx | ios"
+    },
+    "cppwinrt": {
+      "description": "Build with C++/WinRT projection headers (Windows only)",
+      "supports": "windows",
+      "dependencies": [
+        "cppwinrt"
+      ]
+    },
     "cuda": {
       "description": "Build with CUDA support",
       "supports": "(x64 & windows & !static) | (x64 & linux)",
@@ -71,9 +107,45 @@
         "nvidia-cutlass"
       ]
     },
+    "directml": {
+      "description": "Build with DirectML execution provider (Windows only)",
+      "supports": "windows & !uwp",
+      "dependencies": [
+        "directml"
+      ]
+    },
+    "directx-headers": {
+      "description": "Build with DirectX headers (Windows only)",
+      "supports": "windows",
+      "dependencies": [
+        "directx-headers"
+      ]
+    },
+    "dnnl": {
+      "description": "Build with oneDNN (DNNL) execution provider",
+      "supports": "!android & !ios"
+    },
     "framework": {
       "description": "Build a macOS/iOS framework, Objective-C library",
       "supports": "osx | ios"
+    },
+    "migraphx": {
+      "description": "Build with AMD MIGraphX execution provider",
+      "supports": "linux"
+    },
+    "mimalloc": {
+      "description": "Build with mimalloc allocator",
+      "dependencies": [
+        "mimalloc"
+      ]
+    },
+    "nccl": {
+      "description": "Build with NCCL support for distributed training",
+      "supports": "linux"
+    },
+    "nnapi": {
+      "description": "Build with NNAPI execution provider (Android only)",
+      "supports": "android"
     },
     "openvino": {
       "description": "Build with OpenVINO support",
@@ -90,6 +162,22 @@
         }
       ]
     },
+    "qnn": {
+      "description": "Build with Qualcomm QNN execution provider",
+      "supports": "(windows | linux | android) & (x64 | arm64)"
+    },
+    "rknpu": {
+      "description": "Build with Rockchip RKNPU execution provider",
+      "supports": "linux & arm64"
+    },
+    "snpe": {
+      "description": "Build with Qualcomm SNPE execution provider",
+      "supports": "android"
+    },
+    "telemetry": {
+      "description": "Build with telemetry support",
+      "supports": "windows"
+    },
     "tensorrt": {
       "description": "Build with TensorRT support",
       "dependencies": [
@@ -101,6 +189,28 @@
           ]
         }
       ]
+    },
+    "test": {
+      "description": "Build unit tests and benchmarks"
+    },
+    "training": {
+      "description": "Enable full training functionality including ORTModule and ORT Training APIs"
+    },
+    "vitisai": {
+      "description": "Build with AMD Vitis-AI execution provider"
+    },
+    "vsinpu": {
+      "description": "Build with VSI NPU execution provider"
+    },
+    "webnn": {
+      "description": "Build with WebNN execution provider for browser hardware acceleration"
+    },
+    "winml": {
+      "description": "Build with WinML support",
+      "supports": "windows & !uwp"
+    },
+    "xnnpack": {
+      "description": "Build with XNNPACK execution provider"
     }
   }
 }

--- a/custom-steps/onnxruntime/disable-onnx-static-registration.patch
+++ b/custom-steps/onnxruntime/disable-onnx-static-registration.patch
@@ -1,0 +1,14 @@
+diff --git a/ports/onnx/portfile.cmake b/ports/onnx/portfile.cmake
+index 9a34e56d..47819fe4 100644
+--- a/ports/onnx/portfile.cmake
++++ b/ports/onnx/portfile.cmake
+@@ -38,6 +38,9 @@ vcpkg_cmake_configure(
+         -DONNX_USE_MSVC_STATIC_RUNTIME=${USE_STATIC_RUNTIME}
+         -DONNX_BUILD_TESTS=OFF
+         -DONNX_BUILD_CUSTOM_PROTOBUF=OFF
++        # <TechSmith Customization>
++        -DONNX_DISABLE_STATIC_REGISTRATION=ON
++        # </TechSmith Customization>
+     MAYBE_UNUSED_VARIABLES
+         ONNX_USE_MSVC_STATIC_RUNTIME
+         Python_EXECUTABLE

--- a/custom-steps/onnxruntime/pre-build.ps1
+++ b/custom-steps/onnxruntime/pre-build.ps1
@@ -1,0 +1,14 @@
+Import-Module "$PSScriptRoot/../../scripts/ps-modules/Build" -DisableNameChecking
+
+# Patch the vcpkg 'onnx' port to add ONNX_DISABLE_STATIC_REGISTRATION=ON.
+# When onnx is statically linked into onnxruntime.dll (as our custom triplet does),
+# the ONNX schema registration runs twice at DLL load time — once from C++ static
+# initializers and once from ORT's own initialization — producing ~611 duplicate
+# "already registered" warnings on stderr. This flag disables the static initializer
+# registration, eliminating the duplicates.
+Write-Message "Applying TechSmith patch to vcpkg onnx port (ONNX_DISABLE_STATIC_REGISTRATION)..."
+$patchSuccess = Apply-VcpkgPortPatch -PortName "onnx" -PatchFile "$PSScriptRoot/disable-onnx-static-registration.patch"
+if (-not $patchSuccess) {
+    Write-Message "FATAL: Failed to apply patch to onnx port" -Error
+    exit 1
+}

--- a/custom-triplets/onnxruntime/arm64-osx-dynamic-release.cmake
+++ b/custom-triplets/onnxruntime/arm64-osx-dynamic-release.cmake
@@ -1,0 +1,23 @@
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
+set(VCPKG_OSX_ARCHITECTURES arm64)
+
+set(VCPKG_BUILD_TYPE release)
+
+# BinSkim-compliant security hardening flags (matches Microsoft's official onnxruntime build)
+set(VCPKG_C_FLAGS "-mmacosx-version-min=11.0 -g -gdwarf-2 -fvisibility=hidden -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -O3 -pipe")
+set(VCPKG_CXX_FLAGS "-mmacosx-version-min=11.0 -g -gdwarf-2 -fvisibility=hidden -fvisibility-inlines-hidden -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -O3 -pipe")
+set(VCPKG_LINKER_FLAGS -mmacosx-version-min=11.0)
+
+# C++20 for ABI consistency (esp. abseil inline namespace) — matches ORT's CMakeLists.txt for Apple
+set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_CXX_STANDARD=20")
+
+# Force ORT dependencies to static linkage so they're embedded into libonnxruntime.dylib.
+# This avoids shipping separate libprotobuf.dylib, libre2.dylib, etc.
+# Matches the pattern used in onnxruntime/x64-windows-dynamic-release.cmake.
+if(PORT MATCHES "^(protobuf|abseil|re2|date|onnx|utf8-range|cpuinfo)$")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif()

--- a/custom-triplets/onnxruntime/x64-osx-dynamic-release.cmake
+++ b/custom-triplets/onnxruntime/x64-osx-dynamic-release.cmake
@@ -1,0 +1,22 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
+set(VCPKG_OSX_ARCHITECTURES x86_64)
+set(VCPKG_BUILD_TYPE release)
+
+# BinSkim-compliant security hardening flags (matches Microsoft's official onnxruntime build)
+set(VCPKG_C_FLAGS "-mmacosx-version-min=11.0 -g -gdwarf-2 -fvisibility=hidden -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -O3 -pipe")
+set(VCPKG_CXX_FLAGS "-mmacosx-version-min=11.0 -g -gdwarf-2 -fvisibility=hidden -fvisibility-inlines-hidden -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -O3 -pipe")
+set(VCPKG_LINKER_FLAGS -mmacosx-version-min=11.0)
+
+# C++20 for ABI consistency (esp. abseil inline namespace) — matches ORT's CMakeLists.txt for Apple
+set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_CXX_STANDARD=20")
+
+# Force ORT dependencies to static linkage so they're embedded into libonnxruntime.dylib.
+# This avoids shipping separate libprotobuf.dylib, libre2.dylib, etc.
+# Matches the pattern used in onnxruntime/x64-windows-dynamic-release.cmake.
+if(PORT MATCHES "^(protobuf|abseil|re2|date|onnx|utf8-range|cpuinfo)$")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif()

--- a/custom-triplets/onnxruntime/x64-windows-dynamic-debug.cmake
+++ b/custom-triplets/onnxruntime/x64-windows-dynamic-debug.cmake
@@ -1,0 +1,11 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+set(VCPKG_BUILD_TYPE debug)
+
+# Special handling for ONNX Runtime dependencies
+# Force these dependencies to be static so they're embedded into onnxruntime.dll
+# This avoids shipping separate protobuf.dll, re2.dll, abseil_dll.dll, etc.
+if(PORT MATCHES "^(protobuf|abseil|re2|date|onnx|utf8-range)$")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif()

--- a/custom-triplets/onnxruntime/x64-windows-dynamic-release.cmake
+++ b/custom-triplets/onnxruntime/x64-windows-dynamic-release.cmake
@@ -1,0 +1,11 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+set(VCPKG_BUILD_TYPE release)
+
+# Special handling for ONNX Runtime dependencies
+# Force these dependencies to be static so they're embedded into onnxruntime.dll
+# This avoids shipping separate protobuf.dll, re2.dll, abseil_dll.dll, etc.
+if(PORT MATCHES "^(protobuf|abseil|re2|date|onnx|utf8-range)$")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif()

--- a/invoke-build.ps1
+++ b/invoke-build.ps1
@@ -3,7 +3,7 @@ param(
     [string]$LinkType,                                       # Linking type: static or dynamic
     [string]$PackageName = "",                               # The base name of the tag to be used when publishing the release (ex. "openssl-static").  If not specified, it will default to "$Package-$LinkType"
     [string]$BuildType = "release",                          # Build type: release or debug
-    [string]$CustomTriplet = "",                             # Optional: Custom triplet to use for vcpkg. Overrides LinkType and BuildType
+    [string[]]$CustomTriplets = @(),                        # Optional: Custom triplet(s) to use for vcpkg. Overrides LinkType and BuildType
     [string]$StagedArtifactsPath = "StagedArtifacts",        # Output path to stage these artifacts to
     [string]$VcpkgHash = "",                                 # The hash of vcpkg to checkout (if applicable)
     [PSObject]$PublishInfo = $false,                         # Optional info on what to publish or not publish to the final artifact
@@ -17,12 +17,12 @@ Run-CleanupStep
 Run-SetupVcPkgStep $VcPkgHash
 Run-PreBuildStep $PackageAndFeatures
 
-$triplets = Get-Triplets -linkType $linkType -buildType $BuildType -customTriplet $CustomTriplet
+$triplets = Get-Triplets -linkType $linkType -buildType $BuildType -customTriplets $CustomTriplets
 Run-InstallCompilerIfNecessary -triplets $triplets
 Run-InstallPackageStep -packageAndFeatures $PackageAndFeatures -triplets $triplets
 Run-PrestageAndFinalizeBuildArtifactsStep -triplets $triplets -publishInfo $PublishInfo
 Run-PostBuildStep -packageAndFeatures $PackageAndFeatures -linkType $LinkType -buildType $BuildType -triplets $triplets
-Run-StageBuildArtifactsStep -packageName $PackageName -packageAndFeatures $PackageAndFeatures -linkType $LinkType -buildType $BuildType -customTriplet $CustomTriplet -stagedArtifactsPath $StagedArtifactsPath -publishInfo $PublishInfo
-Run-StageSourceArtifactsStep -packageName $PackageName -packageAndFeatures $PackageAndFeatures -linkType $LinkType -buildType $BuildType -customTriplet $CustomTriplet -stagedArtifactsPath $StagedArtifactsPath
+Run-StageBuildArtifactsStep -packageName $PackageName -packageAndFeatures $PackageAndFeatures -linkType $LinkType -buildType $BuildType -customTriplets $CustomTriplets -stagedArtifactsPath $StagedArtifactsPath -publishInfo $PublishInfo
+Run-StageSourceArtifactsStep -packageName $PackageName -packageAndFeatures $PackageAndFeatures -linkType $LinkType -buildType $BuildType -customTriplets $CustomTriplets -stagedArtifactsPath $StagedArtifactsPath
 
 Write-Message "$(NL)$(NL)Done.$(NL)"

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -411,6 +411,19 @@
         "buildType": "release",
         "vcpkgHash": "2026.03.18"
       }
+    },
+    {
+      "name": "onnxruntime",
+      "mac": {
+        "package": "onnxruntime",
+        "customTriplets": ["onnxruntime/x64-osx-dynamic-release", "onnxruntime/arm64-osx-dynamic-release"],
+        "vcpkgHash": "2026.03.18"
+      },
+      "win": {
+        "package": "onnxruntime",
+        "customTriplets": ["onnxruntime/x64-windows-dynamic-release"],
+        "vcpkgHash": "2026.03.18"
+      }
     }
   ]
 }

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -424,6 +424,15 @@
         "customTriplets": ["onnxruntime/x64-windows-dynamic-release"],
         "vcpkgHash": "2026.03.18"
       }
+    },
+    {
+      "name": "directx-headers",
+      "win": {
+        "package": "directx-headers",
+        "linkType": "static",
+        "buildType": "release",
+        "vcpkgHash": "2026.03.18"
+      }
     }
   ]
 }

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -64,7 +64,7 @@
         "package": "ffmpeg[tsc-wasm-base]",
         "linkType": "dynamic",
         "buildType": "release",
-        "customTriplet": "wasm32-emscripten-dynamic",
+        "customTriplets": ["wasm32-emscripten-dynamic"],
         "vcpkgHash": "2025.04.09"
       }
     },
@@ -319,7 +319,7 @@
       "name": "openblas",
       "win": {
         "package": "openblas",
-        "customTriplet": "x64-windows-static-md",
+        "customTriplets": ["x64-windows-static-md"],
         "publish": {
           "debug": true
         }
@@ -334,7 +334,7 @@
       },
       "win": {
         "package": "kaldi",
-        "customTriplet": "x64-windows-static-md",
+        "customTriplets": ["x64-windows-static-md"],
         "publish": {
           "debug": true
         }
@@ -349,7 +349,7 @@
       },
       "win": {
         "package": "glslang",
-        "customTriplet": "x64-windows-static-md",
+        "customTriplets": ["x64-windows-static-md"],
         "publish": {
           "debug": true
         }
@@ -364,7 +364,7 @@
       },
       "win": {
         "package": "dawn",
-        "customTriplet": "x64-windows-static-md",
+        "customTriplets": ["x64-windows-static-md"],
         "publish": {
           "debug": true
         }

--- a/scripts/ps-modules/Build/Build.psm1
+++ b/scripts/ps-modules/Build/Build.psm1
@@ -9,9 +9,21 @@ function Install-FromVcpkg {
         [string]$triplet
     )
 
-    $pkgToInstall = "${packageAndFeatures}:${triplet}"
+    # Extract subdirectory from triplet if it contains a path separator
+    # e.g., "onnxruntime/x64-windows-dynamic-release-static-deps" -> overlay-triplets="custom-triplets/onnxruntime"
+    $overlayTripletsPath = "custom-triplets"
+    if ($triplet -match '^(.+?)/(.+)$') {
+        $tripletSubdir = $Matches[1]
+        $tripletName = $Matches[2]
+        $overlayTripletsPath = "custom-triplets/$tripletSubdir"
+    } else {
+        $tripletName = $triplet
+    }
+
+    $pkgToInstall = "${packageAndFeatures}:${tripletName}"
     Write-Message "Installing package: `"$pkgToInstall`""
-    Invoke-Expression "./$(Get-VcPkgExe) install `"$pkgToInstall`" --overlay-triplets=`"custom-triplets`" --overlay-ports=`"custom-ports`""
+    Write-Message "Using overlay-triplets path: `"$overlayTripletsPath`""
+    Invoke-Expression "./$(Get-VcPkgExe) install `"$pkgToInstall`" --overlay-triplets=`"$overlayTripletsPath`" --overlay-ports=`"custom-ports`""
 }
 
 function Get-PackageNameOnly {
@@ -25,12 +37,17 @@ function Get-Triplets {
    param(
       [string]$linkType,
       [string]$buildType,
-      [string]$customTriplet
+      [string[]]$customTriplets = @()
    )
 
-   if ( -not [string]::IsNullOrEmpty($customTriplet) ) {
-       return @($customTriplet)
-   }
+   # Filter out any null/empty values that may result from JSON deserialization
+   if($customTriplets -ne $null)
+   {
+	   $customTriplets = @($customTriplets | Where-Object { -not [string]::IsNullOrEmpty($_) })
+	   if ($customTriplets.Count -gt 0) {
+	       return $customTriplets
+	   }
+  }
 
    if (Get-IsOnWindowsOS) {
        return @("x64-windows-$linkType-$buildType")
@@ -61,7 +78,7 @@ function Get-ArtifactName {
       [string]$packageAndFeatures,
       [string]$linkType,
       [string]$buildType,
-      [string]$customTriplet
+      [string[]]$customTriplets = @()
    )
 
    if( $packageName -eq "") {
@@ -69,8 +86,15 @@ function Get-ArtifactName {
       $packageName = "$packageNameOnly-$linkType"
    }
 
-   if($null -ne $customTriplet) {
-       $buildName = $customTriplet
+   if($customTriplets -ne $null -and $customTriplets.Count -gt 0) {
+       $firstTriplet = $customTriplets[0]
+       # Extract just the triplet name from subdirectory paths like "onnxruntime/x64-windows-dynamic-release"
+       # The subdirectory prefix is only needed for vcpkg overlay-triplets, not for artifact naming
+       if ($firstTriplet -match '^.+?/(.+)$') {
+           $buildName = $Matches[1]  # Use only the triplet filename (e.g., "x64-windows-dynamic-release")
+       } else {
+           $buildName = $firstTriplet  # No subdirectory, use as-is
+       }
    } else {
        $buildName = $buildType
    }
@@ -323,15 +347,28 @@ function Run-PrestageAndFinalizeBuildArtifactsStep {
    $binDir = "bin"
    $toolsDir = "tools"
 
-   # If we're on MacOS and we didn't specify a custom triplet, we're building a universal binary
-   # If we specify a custom triplet, we can only build one architecture at a time
+   # Universal binary: on macOS with two triplets (x64 + arm64), we lipo them together
    $isUniversalBinary = ((Get-IsOnMacOS) -and ($triplets.Count -eq 2))
 
    # Get dirs to copy
    $srcToDestDirs = @{}
    if($isUniversalBinary) {
-      $srcX64Dir = "./vcpkg/installed/$($triplets[0])"
-      $srcArm64Dir = "./vcpkg/installed/$($triplets[1])"
+      # Identify x64 vs arm64 triplets by name rather than relying on array ordering.
+      # Strip subdirectory prefix if present (e.g., "onnxruntime/x64-osx-dynamic-release" -> "x64-osx-dynamic-release")
+      # since vcpkg installs to just the triplet name, not the overlay-triplets subdirectory path.
+      $tripletX64 = $null
+      $tripletArm64 = $null
+      foreach ($t in $triplets) {
+         $stripped = $t
+         if ($t -match '^.+?/(.+)$') { $stripped = $Matches[1] }
+         if ($stripped -like "x64-*") { $tripletX64 = $stripped }
+         elseif ($stripped -like "arm64-*") { $tripletArm64 = $stripped }
+      }
+      if ($null -eq $tripletX64 -or $null -eq $tripletArm64) {
+         throw "Universal binary build requires one x64 and one arm64 triplet, got: $($triplets -join ', ')"
+      }
+      $srcX64Dir = "./vcpkg/installed/$tripletX64"
+      $srcArm64Dir = "./vcpkg/installed/$tripletArm64"
       $destArm64LibDir = "$preStagePath/arm64Lib"
       $destX64LibDir = "$preStagePath/x64Lib"
       $destArm64ToolsDir = "$preStagePath/arm64Tools"
@@ -347,6 +384,11 @@ function Run-PrestageAndFinalizeBuildArtifactsStep {
    }
    else {
       $firstTriplet = $triplets | Select-Object -First 1
+      # Strip subdirectory prefix if present (e.g., "onnxruntime/x64-windows-dynamic-release" -> "x64-windows-dynamic-release")
+      # This matches the behavior in Install-FromVcpkg where vcpkg installs using only the triplet name
+      if ($firstTriplet -match '^.+?/(.+)$') {
+         $firstTriplet = $Matches[1]
+      }
       $mainSrcDir = "./vcpkg/installed/$firstTriplet"
       $srcToDestDirs = @{
          "$mainSrcDir/include" = "$preStagePath/include"
@@ -425,7 +467,7 @@ function Run-StageBuildArtifactsStep {
       [string]$packageAndFeatures,
       [string]$linkType,
       [string]$buildType,
-      [string]$customTriplet,
+      [string[]]$customTriplets = @(),
       [string]$stagedArtifactsPath,
       [PSObject]$publishInfo,
       [bool]$deletePrestageDir = $true
@@ -434,7 +476,7 @@ function Run-StageBuildArtifactsStep {
    Write-Banner -Level 3 -Title "Stage build artifacts"
 
    $stagedArtifactSubDir = "$stagedArtifactsPath/bin"
-   $artifactName = "$((Get-ArtifactName -packageName $packageName -packageAndFeatures $packageAndFeatures -linkType $linkType -buildType $buildType -customTriplet $customTriplet))-bin"
+   $artifactName = "$((Get-ArtifactName -packageName $packageName -packageAndFeatures $packageAndFeatures -linkType $linkType -buildType $buildType -customTriplets $customTriplets))-bin"
    New-Item -Path $stagedArtifactSubDir/$artifactName -ItemType Directory -Force -ErrorAction SilentlyContinue | Out-Null
 
    $dependenciesFilename = "dependencies.json"
@@ -482,14 +524,14 @@ function Run-StageSourceArtifactsStep {
       [string]$packageAndFeatures,
       [string]$linkType,
       [string]$buildType,
-      [string]$customTriplet,
+      [string[]]$customTriplets = @(),
       [string]$stagedArtifactsPath
    )
 
    Write-Banner -Level 3 -Title "Stage source code artifacts"
 
    $sourceCodeRootDir = "./vcpkg/buildtrees/"
-   $artifactName = "$((Get-ArtifactName -packageName $packageName -packageAndFeatures $packageAndFeatures -linkType $linkType -buildType $buildType -customTriplet $customTriplet))-src"
+   $artifactName = "$((Get-ArtifactName -packageName $packageName -packageAndFeatures $packageAndFeatures -linkType $linkType -buildType $buildType -customTriplets $customTriplets))-src"
    $stagedArtifactSubDir = "$stagedArtifactsPath/src"
    $artifactPath = "$stagedArtifactSubDir/$artifactName"
 

--- a/scripts/ps-modules/Build/Build.psm1
+++ b/scripts/ps-modules/Build/Build.psm1
@@ -108,7 +108,7 @@ function Copy-ItemWithSymlinks {
       New-Item -ItemType Container -Path $destination | Out-Null
    }
 
-   $items = Get-ChildItem -Path $source
+   $items = Get-ChildItem -LiteralPath $source
    foreach ($item in $items) {
        $relativePath = $item.FullName.Substring($source.Length + 1)
        $destPath = Join-Path -Path $destination -ChildPath $relativePath
@@ -121,7 +121,7 @@ function Copy-ItemWithSymlinks {
             Copy-ItemWithSymlinks -source $item.FullName -destination $destPath
          }
          else {
-            Copy-Item -Path "$($item.FullName)" -Destination "$destPath" -Force | Out-Null
+            Copy-Item -LiteralPath "$($item.FullName)" -Destination "$destPath" -Force | Out-Null
          }
        }
    }
@@ -497,7 +497,7 @@ function Run-StageSourceArtifactsStep {
    if (-not (Test-Path -Path $artifactPath)) {
        New-Item -ItemType Directory -Path $artifactPath | Out-Null
    }
-   $buildTreesSubDirs = Get-ChildItem -Path $sourceCodeRootDir -Directory
+   $buildTreesSubDirs = Get-ChildItem -LiteralPath $sourceCodeRootDir -Directory
    foreach ($buildTreesSubDir in $buildTreesSubDirs) {
        $srcDir = Join-Path -Path $buildTreesSubDir.FullName -ChildPath "src"
        if (Test-Path -Path $srcDir) {


### PR DESCRIPTION
# Description
This PR adds ONNX Runtime 1.23.2 support to the ThirdParty-Packages-vcpkg repository with support for multiple execution providers and custom build configurations.

## What was added:

1. **ONNX Runtime 1.23.2 port** from microsoft/vcpkg@2026.03.18 with additional execution providers
   - DirectML execution provider for GPU acceleration on Windows
   - CoreML execution provider for macOS
   - CPU execution provider (default)
   - WinML adapter support with GPU acceleration

2. **Custom dependency ports:**
   - `flatbuffers-onnxruntime` 23.5.26 (from microsoft/vcpkg@2024.01.12) - Required specific version for onnxruntime compatibility
   - `directml` 1.15.4 - Custom port for DirectML GPU acceleration on Windows

3. **Custom triplets for onnxruntime** with static dependency embedding:
   - Windows: `x64-windows-dynamic-release` and `x64-windows-dynamic-debug`
   - macOS: `x64-osx-dynamic-release` and `arm64-osx-dynamic-release`
   - All configured with BinSkim compliance flags and static dependency embedding

4. **Build system enhancements:**
   - Added subdirectory-based custom triplet support to allow per-package triplet organization
   - Changed `preconfigured-packages.json` schema from `customTriplet` → `customTriplets` to support multiple triplets
   - Added onnxruntime and directx-headers to preconfigured packages for easy testing via `build-package.ps1`
   - Updated pipeline configuration to include onnxruntime and directx-headers builds

5. **Custom build steps:**
   - Pre-build step to disable ONNX static schema registration (resolves linker errors)
   - WinML feature enabled by default on Windows builds
   - Added WindowsApp.lib dependency to fix WinML linker errors

6. **TechSmith patches:**
   - `1001-tsc-fix-coreml.patch` - Fixes CoreML execution provider build issues
   - `1002-tsc-fix-winml-wcos-check.patch` - Fixes WCOS (Windows Core OS) build errors when building with WinML adapter
   - `1000-tsc-disable-hardcoded-msvc-runtime-flags.patch` (flatbuffers) - Removes hardcoded MSVC runtime flags
   - `disable-onnx-static-registration.patch` - Disables static schema registration to avoid linker errors

7. **Infrastructure improvements:**
   - Added `_private` directory to `.gitignore` for local development files
   - Fixed PowerShell wildcard pattern error for filenames with brackets in `build-package.ps1`

## Execution Providers Supported:
- **CPU** - Default, cross-platform
- **DirectML** - Windows GPU acceleration using DirectX 12
- **CoreML** - macOS hardware acceleration
- **WinML** - Windows ML adapter with GPU support

## CI Builds

| Package | Run ID | Status | Link |
|---------|--------|--------|------|
| `onnxruntime` | 674293 | :hourglass_flowing_sand: IN PROGRESS | [Build](https://dev.azure.com/techsmith/1dc1e8d6-0859-4ce8-88b6-a92b32a68ffa/_build/results?buildId=674293) |
| `directx-headers` | 674295 | :hourglass_flowing_sand: IN PROGRESS | [Build](https://dev.azure.com/techsmith/1dc1e8d6-0859-4ce8-88b6-a92b32a68ffa/_build/results?buildId=674295) |

- `onnxruntime` publishing to GitHub release with `-tmp-20260504-1749` suffix
- `directx-headers` publishing to GitHub release with `-tmp-20260504-1758` suffix
