### PR TITLE
Remove Mac support from ffmpeg-desktop-hevc

### DIFF
--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -31,19 +31,6 @@
     },
     {
       "name": "ffmpeg-desktop-hevc",
-      "mac": {
-        "package": "ffmpeg[tsc-desktop-mac,encoder-hevc-videotoolbox,decoder-hevc,demuxer-hevc,parser-hevc]",
-        "linkType": "dynamic",
-        "buildType": "release",
-        "vcpkgHash": "2025.04.09",
-        "publish": {
-          "include": true,
-          "lib": true,
-          "bin": true,
-          "share": true,
-          "tools": true
-        }
-      },
       "win": {
         "package": "ffmpeg[tsc-desktop-win,encoder-hevc-mf,encoder-hevc-qsv,decoder-hevc,decoder-hevc-qsv,demuxer-hevc,parser-hevc]",
         "linkType": "dynamic",


### PR DESCRIPTION
# Description
This removes HEVC decoding support for desktop Mac FFmpeg builds.  TechSmith does not ship any product that uses HEVC decoding on Mac via FFmpeg, currently, so there is no value in maintaining and verifying a Mac build of this package variant.

# Testing
- [ ] ⌛ Built `ffmpeg-desktop-hevc` without publishing it to a release.  Verified this built successfully for Windows, but did NOT build for Mac: https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_build/results?buildId=671079&view=results
- [ ] ⌛ Built `ffmpeg-desktop-base` without publishing it to a release.  Verified this built successfully for Windows AND Mac still: https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_build/results?buildId=671085&view=results