### PR TITLE
Add boost-tsc preconfigured package

### DIFF
--- a/.pipelines/build-package-preconfigured.yml
+++ b/.pipelines/build-package-preconfigured.yml
@@ -10,6 +10,7 @@ parameters:
   displayName: Package to install (builds as a dynamic library, unless otherwise specified)
   type: string
   values:
+  - boost-tsc
   - buildcache
   - dawn
   - ffmpeg-cloud-gpl

--- a/custom-ports/boost-tsc/portfile.cmake
+++ b/custom-ports/boost-tsc/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/custom-ports/boost-tsc/vcpkg.json
+++ b/custom-ports/boost-tsc/vcpkg.json
@@ -1,0 +1,80 @@
+{
+  "name": "boost-tsc",
+  "version": "1.90.0",
+  "description": "TechSmith-curated subset of Boost C++ libraries",
+  "homepage": "https://www.boost.org",
+  "license": "BSL-1.0",
+  "default-features": [
+    "atomic",
+    "chrono",
+    "date-time",
+    "filesystem",
+    "program-options",
+    "regex",
+    "serialization",
+    "system",
+    "thread"
+  ],
+  "features": {
+    "atomic": {
+      "description": "Boost.Atomic - C++11-style atomic<> for pre-C++11 compilers",
+      "dependencies": [
+        "boost-atomic"
+      ]
+    },
+    "chrono": {
+      "description": "Boost.Chrono - Useful time utilities",
+      "dependencies": [
+        "boost-chrono"
+      ]
+    },
+    "date-time": {
+      "description": "Boost.DateTime - Date/time types and operations",
+      "dependencies": [
+        "boost-date-time"
+      ]
+    },
+    "filesystem": {
+      "description": "Boost.Filesystem - Portable file system paths and operations",
+      "dependencies": [
+        "boost-filesystem"
+      ]
+    },
+    "program-options": {
+      "description": "Boost.ProgramOptions - Command line and config file option parsing",
+      "dependencies": [
+        "boost-program-options"
+      ]
+    },
+    "regex": {
+      "description": "Boost.Regex - Regular expression library",
+      "dependencies": [
+        "boost-regex"
+      ]
+    },
+    "serialization": {
+      "description": "Boost.Serialization - Object serialization and deserialization",
+      "dependencies": [
+        "boost-serialization"
+      ]
+    },
+    "system": {
+      "description": "Boost.System - Operating system support including error codes",
+      "dependencies": [
+        "boost-system"
+      ]
+    },
+    "thread": {
+      "description": "Boost.Thread - Portable multi-threading",
+      "dependencies": [
+        "boost-thread"
+      ]
+    },
+    "process": {
+      "description": "Boost.Process - Process launching and management",
+      "dependencies": [
+        "boost-process"
+      ]
+    }
+  }
+}

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -371,6 +371,23 @@
       }
     },
     {
+      "name": "boost-tsc",
+      "mac": {
+        "package": "boost-tsc[process]",
+        "linkType": "static",
+        "buildType": "release",
+        "vcpkgHash": "2026.04.27"
+      },
+      "win": {
+        "package": "boost-tsc",
+        "customTriplet": "x64-windows-static-md",
+        "vcpkgHash": "2026.04.27",
+        "publish": {
+          "debug": true
+        }
+      }
+    },
+    {
       "name": "buildcache",
       "mac": {
         "package": "buildcache",


### PR DESCRIPTION
## Summary
- Adds a boost-tsc custom overlay port with feature-flag selection of individual Boost libraries
- Mac additionally enables process feature to match existing boost-1.90.0-mac repo
- Windows builds as static with debug (x64-windows-static-md triplet) to match existing boost-1.90.0-win repo
- Pinned to vcpkg tag 2026.04.27 (boost 1.90.0)
- Successfully tested locally on Windows (2.5 min build time)

## Test Steps
- [Pipeline Run 671334](https://dev.azure.com/techsmith/1dc1e8d6-0859-4ce8-88b6-a92b32a68ffa/_build/results?buildId=671334) - Building boost-tsc on branch add/boost with publish to GitHub release (suffix: tmp-20260430-1729)