### PR TITLE
Correct fileVersion metadata on ffmpeg 7.1.2 dlls

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,15 +124,11 @@ When setting up a new package or updating an existing package that needs DLL ver
 
 ```powershell
 # Step 1: Build your package locally on Windows to generate DLLs and metadata
-./build-package.ps1 -PackageName mypackage
+./build-package.ps1 -PackageName pango-desktop
 
 # Step 2: Generate or update the version-info.json from the built DLLs
 # The script will automatically enrich metadata from vcpkg sources
-./scripts/tools/update-version-info-json.ps1 `
-    -InputDllDir "./vcpkg/installed/x64-windows-dynamic-release/bin" `
-    -OutputJsonFile "./custom-steps/mypackage/version-info.json" `
-    -VcpkgRoot "./vcpkg" `
-    -Triplet "x64-windows-dynamic-release"
+./scripts/update-version-info-json.ps1 -InputDllDir "./vcpkg/installed/x64-windows-dynamic-release/bin" -OutputJsonFile "./custom-steps/pango/version-info.json" -VcpkgRoot "./vcpkg" -Triplet "x64-windows-dynamic-release"
 ```
 
 This script will:

--- a/custom-ports/ffmpeg/1002-tsc-avcodec-fix-version-micro.patch
+++ b/custom-ports/ffmpeg/1002-tsc-avcodec-fix-version-micro.patch
@@ -1,0 +1,13 @@
+diff --git a/libavcodec/version.h b/libavcodec/version.h
+index b6ca025..246f59d 100644
+--- a/libavcodec/version.h
++++ b/libavcodec/version.h
+@@ -30,7 +30,7 @@
+ #include "version_major.h"
+ 
+ #define LIBAVCODEC_VERSION_MINOR  19
+-#define LIBAVCODEC_VERSION_MICRO 101
++#define LIBAVCODEC_VERSION_MICRO 102
+ 
+ #define LIBAVCODEC_VERSION_INT  AV_VERSION_INT(LIBAVCODEC_VERSION_MAJOR, \
+                                                LIBAVCODEC_VERSION_MINOR, \

--- a/custom-ports/ffmpeg/portfile.cmake
+++ b/custom-ports/ffmpeg/portfile.cmake
@@ -19,6 +19,7 @@ vcpkg_from_github(
         0043-fix-miss-head.patch
         0044-fix-vulkan-debug-callback-abi.patch
         1001-tsc-disable-aac-non-lc-profiles.patch
+        1002-tsc-avcodec-fix-version-micro.patch
 )
 
 if(SOURCE_PATH MATCHES " ")
@@ -581,9 +582,11 @@ endif()
 
 if(VCPKG_DETECTED_CMAKE_RC_COMPILER)
     get_filename_component(RC_path "${VCPKG_DETECTED_CMAKE_RC_COMPILER}" DIRECTORY)
-    get_filename_component(RC_filename "${VCPKG_DETECTED_CMAKE_RC_COMPILER}" NAME)
-    set(ENV{WINDRES} "${RC_filename}")
-    string(APPEND OPTIONS " --windres=${RC_filename}")
+    # Do not override --windres here. When --toolchain=msvc is set, ffmpeg's configure
+    # defaults windres to compat/windows/mswindres, a shell wrapper that translates
+    # GNU windres arguments to rc.exe syntax. Passing --windres=rc.exe directly
+    # bypasses that wrapper and causes gnu_windres detection to fail (rc.exe has no
+    # --version flag), resulting in no .rc files being compiled into the DLLs.
     list(APPEND prog_env "${RC_path}")
 endif()
 

--- a/custom-steps/ffmpeg/add-libvorbis-port-patch.patch
+++ b/custom-steps/ffmpeg/add-libvorbis-port-patch.patch
@@ -1,0 +1,12 @@
+diff --git a/ports/libvorbis/portfile.cmake b/ports/libvorbis/portfile.cmake
+index dad9f4f17f..796d0a9bce 100644
+--- a/ports/libvorbis/portfile.cmake
++++ b/ports/libvorbis/portfile.cmake
+@@ -6,6 +6,7 @@ vcpkg_from_github(
+     PATCHES
+         0001-Dont-export-vorbisenc-functions.patch
+         0002-Fixup-pkgconfig-libs.patch
++        1001-tsc-libvorbis-add-windows-version-resources.patch
+         0003-def-mingw-compat.patch
+         0004-ogg-find-dependency.patch
+ )

--- a/custom-steps/ffmpeg/add-mp3lame-port-patch.patch
+++ b/custom-steps/ffmpeg/add-mp3lame-port-patch.patch
@@ -1,0 +1,12 @@
+diff --git a/ports/mp3lame/portfile.cmake b/ports/mp3lame/portfile.cmake
+index dad9f4f17f..796d0a9bce 100644
+--- a/ports/mp3lame/portfile.cmake
++++ b/ports/mp3lame/portfile.cmake
+@@ -5,6 +5,7 @@ vcpkg_from_sourceforge(
+     PATCHES
+         00001-msvc-upgrade-solution-up-to-vc11.patch
+         remove_lame_init_old_from_symbol_list.patch # deprecated https://github.com/zlargon/lame/blob/master/include/lame.h#L169
++        1001-tsc-mp3lame-fix-version-string.patch
+         add-macos-universal-config.patch
+         fix-mingw-w64-compatibility.patch
+ )

--- a/custom-steps/ffmpeg/libvorbis-port-patches/1001-tsc-libvorbis-add-windows-version-resources.patch
+++ b/custom-steps/ffmpeg/libvorbis-port-patches/1001-tsc-libvorbis-add-windows-version-resources.patch
@@ -1,0 +1,136 @@
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index 7cd68e5..637f4e1 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -61,6 +61,26 @@ if(WIN32)
+     list(APPEND VORBIS_SOURCES vorbisenc.c)
+ endif()
+ 
++if(WIN32)
++    get_version_info(VORBISENC_VERSION_INFO "VE_LIB_CURRENT" "VE_LIB_AGE" "VE_LIB_REVISION")
++    get_version_info(VORBISFILE_VERSION_INFO "VF_LIB_CURRENT" "VF_LIB_AGE" "VF_LIB_REVISION")
++    string(REPLACE "." "," VORBISENC_VERSION_INFO_RC ${VORBISENC_VERSION_INFO})
++    string(REPLACE "." "," VORBISFILE_VERSION_INFO_RC ${VORBISFILE_VERSION_INFO})
++    string(REPLACE "." "," PROJECT_VERSION_RC ${PROJECT_VERSION})
++    configure_file(
++        ${CMAKE_CURRENT_SOURCE_DIR}/../win32/vorbis_version.rc.in
++        ${CMAKE_CURRENT_BINARY_DIR}/vorbis_version.rc @ONLY)
++    configure_file(
++        ${CMAKE_CURRENT_SOURCE_DIR}/../win32/vorbisenc_version.rc.in
++        ${CMAKE_CURRENT_BINARY_DIR}/vorbisenc_version.rc @ONLY)
++    configure_file(
++        ${CMAKE_CURRENT_SOURCE_DIR}/../win32/vorbisfile_version.rc.in
++        ${CMAKE_CURRENT_BINARY_DIR}/vorbisfile_version.rc @ONLY)
++    list(APPEND VORBIS_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/vorbis_version.rc)
++    list(APPEND VORBISENC_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/vorbisenc_version.rc)
++    list(APPEND VORBISFILE_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/vorbisfile_version.rc)
++endif()
++
+ if(WIN32)
+     list(APPEND VORBIS_SOURCES ../win32/vorbis.def)
+     list(APPEND VORBISENC_SOURCES ../win32/vorbisenc.def)
+diff --git a/win32/vorbis_version.rc.in b/win32/vorbis_version.rc.in
+new file mode 100644
+index 0000000..3b42958
+--- /dev/null
++++ b/win32/vorbis_version.rc.in
+@@ -0,0 +1,29 @@
++#include <winver.h>
++
++VS_VERSION_INFO VERSIONINFO
++	FILEVERSION @PROJECT_VERSION_RC@,0
++	PRODUCTVERSION @PROJECT_VERSION_RC@,0
++	FILEFLAGSMASK 0x3fL
++	FILEFLAGS 0x0L
++	FILEOS VOS__WINDOWS32
++	FILETYPE VFT_DLL
++	FILESUBTYPE 0x0L
++	BEGIN
++		BLOCK "StringFileInfo"
++		BEGIN
++			BLOCK "040904E4"
++			BEGIN
++				VALUE "CompanyName", "Xiph.Org\0"
++				VALUE "FileDescription", "Ogg Vorbis is a fully open, non-proprietary, patent-and-royalty-free, general-purpose compressed audio format\0"
++				VALUE "FileVersion", "@PROJECT_VERSION@\0"
++				VALUE "LegalCopyright", "Copyright (c) 2002-2020 Xiph.Org Foundation\0"
++				VALUE "OriginalFilename", "vorbis.dll\0"
++				VALUE "ProductName", "Libvorbis\0"
++				VALUE "ProductVersion", "@PROJECT_VERSION@\0"
++			END
++		END
++		BLOCK "VarFileInfo"
++		BEGIN
++			VALUE "Translation", 0x409, 1252
++		END
++	END
+diff --git a/win32/vorbisenc_version.rc.in b/win32/vorbisenc_version.rc.in
+new file mode 100644
+index 0000000..841574d
+--- /dev/null
++++ b/win32/vorbisenc_version.rc.in
+@@ -0,0 +1,29 @@
++#include <winver.h>
++
++VS_VERSION_INFO VERSIONINFO
++	FILEVERSION @VORBISENC_VERSION_INFO_RC@,0
++	PRODUCTVERSION @PROJECT_VERSION_RC@,0
++	FILEFLAGSMASK 0x3fL
++	FILEFLAGS 0x0L
++	FILEOS VOS__WINDOWS32
++	FILETYPE VFT_DLL
++	FILESUBTYPE 0x0L
++	BEGIN
++		BLOCK "StringFileInfo"
++		BEGIN
++			BLOCK "040904E4"
++			BEGIN
++				VALUE "CompanyName", "Xiph.Org\0"
++				VALUE "FileDescription", "Ogg Vorbis is a fully open, non-proprietary, patent-and-royalty-free, general-purpose compressed audio format\0"
++				VALUE "FileVersion", "@VORBISENC_VERSION_INFO@\0"
++				VALUE "LegalCopyright", "Copyright (c) 2002-2020 Xiph.Org Foundation\0"
++				VALUE "OriginalFilename", "vorbisenc.dll\0"
++				VALUE "ProductName", "Libvorbis\0"
++				VALUE "ProductVersion", "@PROJECT_VERSION@\0"
++			END
++		END
++		BLOCK "VarFileInfo"
++		BEGIN
++			VALUE "Translation", 0x409, 1252
++		END
++	END
+diff --git a/win32/vorbisfile_version.rc.in b/win32/vorbisfile_version.rc.in
+new file mode 100644
+index 0000000..233e520
+--- /dev/null
++++ b/win32/vorbisfile_version.rc.in
+@@ -0,0 +1,29 @@
++#include <winver.h>
++
++VS_VERSION_INFO VERSIONINFO
++	FILEVERSION @VORBISFILE_VERSION_INFO_RC@,0
++	PRODUCTVERSION @PROJECT_VERSION_RC@,0
++	FILEFLAGSMASK 0x3fL
++	FILEFLAGS 0x0L
++	FILEOS VOS__WINDOWS32
++	FILETYPE VFT_DLL
++	FILESUBTYPE 0x0L
++	BEGIN
++		BLOCK "StringFileInfo"
++		BEGIN
++			BLOCK "040904E4"
++			BEGIN
++				VALUE "CompanyName", "Xiph.Org\0"
++				VALUE "FileDescription", "Ogg Vorbis is a fully open, non-proprietary, patent-and-royalty-free, general-purpose compressed audio format\0"
++				VALUE "FileVersion", "@VORBISFILE_VERSION_INFO@\0"
++				VALUE "LegalCopyright", "Copyright (c) 2002-2020 Xiph.Org Foundation\0"
++				VALUE "OriginalFilename", "vorbisfile.dll\0"
++				VALUE "ProductName", "Libvorbis\0"
++				VALUE "ProductVersion", "@PROJECT_VERSION@\0"
++			END
++		END
++		BLOCK "VarFileInfo"
++		BEGIN
++			VALUE "Translation", 0x409, 1252
++		END
++	END

--- a/custom-steps/ffmpeg/mp3lame-port-patches/1001-tsc-mp3lame-fix-version-string.patch
+++ b/custom-steps/ffmpeg/mp3lame-port-patches/1001-tsc-mp3lame-fix-version-string.patch
@@ -1,0 +1,13 @@
+diff --git a/libmp3lame/version.h b/libmp3lame/version.h
+index f5fef50..bd544a9 100644
+--- a/libmp3lame/version.h
++++ b/libmp3lame/version.h
+@@ -61,7 +61,7 @@
+ #endif
+ #endif
+ 
+-# define LAME_VERSION_STRING STR(LAME_MAJOR_VERSION) "." STR(LAME_MINOR_VERSION) LAME_PATCH_LEVEL_STRING
++# define LAME_VERSION_STRING STR(LAME_MAJOR_VERSION) "." STR(LAME_MINOR_VERSION) "." STR(LAME_TYPE_VERSION) LAME_PATCH_LEVEL_STRING
+ 
+ #endif /* LAME_VERSION_H */
+ 

--- a/custom-steps/ffmpeg/pre-build.ps1
+++ b/custom-steps/ffmpeg/pre-build.ps1
@@ -1,23 +1,75 @@
 Import-Module "$PSScriptRoot/../../scripts/ps-modules/Build" -DisableNameChecking
 
-if (-not (Get-IsOnMacOS)) {
-    exit
+# ── macOS-only steps ────────────────────────────────────────────────────────
+if (Get-IsOnMacOS) {
+    Write-Message "Installing nasm..."
+    brew install nasm
+
+    # Fix nasm multipass optimization detection in aom's CMake.
+    # nasm 3.x changed its help output format so `-hf` no longer shows `-Ox`.
+    # This patch makes aom use `-hO` to check for multipass support instead.
+    Write-Message "Applying aom nasm multipass fix..."
+    $portDir = "vcpkg/ports/aom"
+    if (Test-Path $portDir) {
+        Copy-Item "$PSScriptRoot/aom-port-patches/1001-tsc-aom-fix-nasm-multipass-check.patch" "$portDir/"
+        $patchSuccess = Apply-VcpkgPortPatch -PortName "aom" -PatchFile "$PSScriptRoot/add-aom-port-patch.patch"
+        if (-not $patchSuccess) {
+            Write-Message "WARNING: Failed to apply aom portfile patch" -Error
+        }
+    } else {
+        Write-Message "WARNING: aom port directory not found, skipping nasm patch"
+    }
 }
 
-Write-Message "Installing nasm..."
-brew install nasm
+# ── Windows-only steps ──────────────────────────────────────────────────────
+if (Get-IsOnWindowsOS) {
 
-# Fix nasm multipass optimization detection in aom's CMake.
-# nasm 3.x changed its help output format so `-hf` no longer shows `-Ox`.
-# This patch makes aom use `-hO` to check for multipass support instead.
-Write-Message "Applying aom nasm multipass fix..."
-$portDir = "vcpkg/ports/aom"
-if (Test-Path $portDir) {
-    Copy-Item "$PSScriptRoot/aom-port-patches/1001-tsc-aom-fix-nasm-multipass-check.patch" "$portDir/"
-    $patchSuccess = Apply-VcpkgPortPatch -PortName "aom" -PatchFile "$PSScriptRoot/add-aom-port-patch.patch"
-    if (-not $patchSuccess) {
-        Write-Message "WARNING: Failed to apply aom portfile patch" -Error
+    # ── mp3lame: fix version string so DLL embeds "3.100.2" instead of "3.100"
+    # LAME 3.100 has LAME_TYPE_VERSION=2 (release) and LAME_PATCH_VERSION=0,
+    # which causes LAME_PATCH_LEVEL_STRING to be "" and the version string to be
+    # "3.100". We patch version.h to always include LAME_TYPE_VERSION as a third
+    # dotted part so the embedded string becomes "3.100.2".
+    $mp3lamePortDir = "vcpkg/ports/mp3lame"
+    $mp3lameVcpkgJson = "$mp3lamePortDir/vcpkg.json"
+    if (Test-Path $mp3lameVcpkgJson) {
+        $mp3lameVersion = (Get-Content $mp3lameVcpkgJson -Raw | ConvertFrom-Json).version
+        if ($mp3lameVersion -eq "3.100") {
+            Write-Message "Applying mp3lame version string fix (3.100 -> 3.100.2)..."
+            Copy-Item "$PSScriptRoot/mp3lame-port-patches/1001-tsc-mp3lame-fix-version-string.patch" "$mp3lamePortDir/"
+            $patchSuccess = Apply-VcpkgPortPatch -PortName "mp3lame" -PatchFile "$PSScriptRoot/add-mp3lame-port-patch.patch"
+            if (-not $patchSuccess) {
+                Write-Message "WARNING: Failed to apply mp3lame portfile patch" -Error
+            }
+        } else {
+            Write-Message "mp3lame version is '$mp3lameVersion' (not 3.100), skipping version string patch"
+        }
+    } else {
+        Write-Message "WARNING: mp3lame port directory not found, skipping version string patch"
     }
-} else {
-    Write-Message "WARNING: aom port directory not found, skipping nasm patch"
+
+    # ── libvorbis: add Windows .rc version resources so vorbis.dll, vorbisenc.dll,
+    # and vorbisfile.dll embed their correct libtool interface versions:
+    #   vorbis.dll     -> 0.4.9   (V_LIB:  current=4, age=4, revision=9)
+    #   vorbisenc.dll  -> 2.0.12  (VE_LIB: current=2, age=0, revision=12)
+    #   vorbisfile.dll -> 3.3.8   (VF_LIB: current=6, age=3, revision=8)
+    # Without this patch the CMake build produces no version resources on Windows,
+    # causing update-version-info-json.ps1 to fall back to the port version (1.3.7)
+    # for all three DLLs.
+    $libvorbisPortDir = "vcpkg/ports/libvorbis"
+    $libvorbisVcpkgJson = "$libvorbisPortDir/vcpkg.json"
+    if (Test-Path $libvorbisVcpkgJson) {
+        $libvorbisVersion = (Get-Content $libvorbisVcpkgJson -Raw | ConvertFrom-Json).version
+        if ($libvorbisVersion -eq "1.3.7") {
+            Write-Message "Applying libvorbis Windows version resource patch (v1.3.7)..."
+            Copy-Item "$PSScriptRoot/libvorbis-port-patches/1001-tsc-libvorbis-add-windows-version-resources.patch" "$libvorbisPortDir/"
+            $patchSuccess = Apply-VcpkgPortPatch -PortName "libvorbis" -PatchFile "$PSScriptRoot/add-libvorbis-port-patch.patch"
+            if (-not $patchSuccess) {
+                Write-Message "WARNING: Failed to apply libvorbis portfile patch" -Error
+            }
+        } else {
+            Write-Message "libvorbis version is '$libvorbisVersion' (not 1.3.7), skipping version resource patch"
+        }
+    } else {
+        Write-Message "WARNING: libvorbis port directory not found, skipping version resource patch"
+    }
 }

--- a/custom-steps/ffmpeg/version-info.json
+++ b/custom-steps/ffmpeg/version-info.json
@@ -1,4 +1,5 @@
 {
+  "buildNumber": 105,
   "files": [
     {
       "filename": "bin/aom.dll",
@@ -10,48 +11,48 @@
     },
     {
       "filename": "bin/avcodec-61.dll",
-      "fileDescription": "A library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations.",
-      "fileVersion": "7.1.2",
-      "productName": "Ffmpeg",
+      "fileDescription": "FFmpeg codec library",
+      "fileVersion": "61.19.102",
+      "productName": "FFmpeg",
       "productVersion": "7.1.2",
-      "copyright": "Copyright (C) 1991, 1999 Free Software Foundation, Inc"
+      "copyright": "Copyright (C) 2000-2025 FFmpeg Project"
     },
     {
       "filename": "bin/avdevice-61.dll",
-      "fileDescription": "A library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations.",
-      "fileVersion": "7.1.2",
-      "productName": "Ffmpeg",
+      "fileDescription": "FFmpeg device handling library",
+      "fileVersion": "61.3.100",
+      "productName": "FFmpeg",
       "productVersion": "7.1.2",
-      "copyright": "Copyright (C) 1991, 1999 Free Software Foundation, Inc"
+      "copyright": "Copyright (C) 2000-2025 FFmpeg Project"
     },
     {
       "filename": "bin/avfilter-10.dll",
-      "fileDescription": "A library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations.",
-      "fileVersion": "7.1.2",
-      "productName": "Ffmpeg",
+      "fileDescription": "FFmpeg audio/video filtering library",
+      "fileVersion": "10.4.100",
+      "productName": "FFmpeg",
       "productVersion": "7.1.2",
-      "copyright": "Copyright (C) 1991, 1999 Free Software Foundation, Inc"
+      "copyright": "Copyright (C) 2000-2025 FFmpeg Project"
     },
     {
       "filename": "bin/avformat-61.dll",
-      "fileDescription": "A library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations.",
-      "fileVersion": "7.1.2",
-      "productName": "Ffmpeg",
+      "fileDescription": "FFmpeg container format library",
+      "fileVersion": "61.7.100",
+      "productName": "FFmpeg",
       "productVersion": "7.1.2",
-      "copyright": "Copyright (C) 1991, 1999 Free Software Foundation, Inc"
+      "copyright": "Copyright (C) 2000-2025 FFmpeg Project"
     },
     {
       "filename": "bin/avutil-59.dll",
-      "fileDescription": "A library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations.",
-      "fileVersion": "7.1.2",
-      "productName": "Ffmpeg",
+      "fileDescription": "FFmpeg utility library",
+      "fileVersion": "59.39.100",
+      "productName": "FFmpeg",
       "productVersion": "7.1.2",
-      "copyright": "Copyright (C) 1991, 1999 Free Software Foundation, Inc"
+      "copyright": "Copyright (C) 2000-2025 FFmpeg Project"
     },
     {
       "filename": "bin/dav1d.dll",
       "fileDescription": "dav1d 1.5.1 - AV1 decoder",
-      "fileVersion": "1.5.1",
+      "fileVersion": "7.0.0",
       "productName": "dav1d",
       "productVersion": "1.5.1",
       "copyright": "Copyright © 2018-2025 VideoLAN and dav1d Authors"
@@ -59,9 +60,9 @@
     {
       "filename": "bin/libmp3lame.dll",
       "fileDescription": "MP3 Encoder.",
-      "fileVersion": "3.100",
+      "fileVersion": "3.100.2",
       "productName": "L.A.M.E.",
-      "productVersion": "3.100",
+      "productVersion": "3.100.2",
       "copyright": "Copyright (C) 1999-2011 The L.A.M.E. Team"
     },
     {
@@ -90,19 +91,19 @@
     },
     {
       "filename": "bin/swresample-5.dll",
-      "fileDescription": "A library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations.",
-      "fileVersion": "7.1.2",
-      "productName": "Ffmpeg",
+      "fileDescription": "FFmpeg audio resampling library",
+      "fileVersion": "5.3.100",
+      "productName": "FFmpeg",
       "productVersion": "7.1.2",
-      "copyright": "Copyright (C) 1991, 1999 Free Software Foundation, Inc"
+      "copyright": "Copyright (C) 2000-2025 FFmpeg Project"
     },
     {
       "filename": "bin/swscale-8.dll",
-      "fileDescription": "A library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations.",
-      "fileVersion": "7.1.2",
-      "productName": "Ffmpeg",
+      "fileDescription": "FFmpeg image rescaling library",
+      "fileVersion": "8.3.100",
+      "productName": "FFmpeg",
       "productVersion": "7.1.2",
-      "copyright": "Copyright (C) 1991, 1999 Free Software Foundation, Inc"
+      "copyright": "Copyright (C) 2000-2025 FFmpeg Project"
     },
     {
       "filename": "bin/vorbis.dll",
@@ -110,32 +111,31 @@
       "fileVersion": "1.3.7",
       "productName": "Libvorbis",
       "productVersion": "1.3.7",
-      "copyright": "Copyright (c) 2002-2020 Xiph"
+      "copyright": "Copyright (c) 2002-2020 Xiph.Org Foundation"
     },
     {
       "filename": "bin/vorbisenc.dll",
       "fileDescription": "Ogg Vorbis is a fully open, non-proprietary, patent-and-royalty-free, general-purpose compressed audio format",
-      "fileVersion": "1.3.7",
+      "fileVersion": "2.0.12",
       "productName": "Libvorbis",
       "productVersion": "1.3.7",
-      "copyright": "Copyright (c) 2002-2020 Xiph"
+      "copyright": "Copyright (c) 2002-2020 Xiph.Org Foundation"
     },
     {
       "filename": "bin/vorbisfile.dll",
       "fileDescription": "Ogg Vorbis is a fully open, non-proprietary, patent-and-royalty-free, general-purpose compressed audio format",
-      "fileVersion": "1.3.7",
+      "fileVersion": "3.3.8",
       "productName": "Libvorbis",
       "productVersion": "1.3.7",
-      "copyright": "Copyright (c) 2002-2020 Xiph"
+      "copyright": "Copyright (c) 2002-2020 Xiph.Org Foundation"
     },
     {
       "filename": "bin/zlib1.dll",
       "fileDescription": "zlib data compression library",
-      "fileVersion": "1.3.1",
+      "fileVersion": "1.3.2",
       "productName": "zlib",
-      "productVersion": "1.3.1",
+      "productVersion": "1.3.2",
       "copyright": "(C) 1995-2026 Jean-loup Gailly & Mark Adler"
     }
-  ],
-  "buildNumber": 100
+  ]
 }

--- a/custom-steps/ffmpeg/version-info.json
+++ b/custom-steps/ffmpeg/version-info.json
@@ -1,5 +1,5 @@
 {
-  "buildNumber": 105,
+  "buildNumber": 107,
   "files": [
     {
       "filename": "bin/aom.dll",

--- a/scripts/update-version-info-json.ps1
+++ b/scripts/update-version-info-json.ps1
@@ -71,6 +71,11 @@ function Normalize-VersionNumber {
     if ([string]::IsNullOrWhiteSpace($Version)) {
         return $Version
     }
+
+    # Normalize comma-separated version strings (e.g. "2, 32, 10, 0" -> "2.32.10.0")
+    if ($Version -match '^\d+,') {
+        $Version = ($Version -split '\s*,\s*' | ForEach-Object { $_.Trim() }) -join '.'
+    }
     
     # Split version by dots
     $parts = $Version -split '\.'
@@ -394,38 +399,67 @@ $results = @(Get-ChildItem -Path "$InputDllDir/" -Filter "*.dll" | ForEach-Objec
             
             # Use port metadata to fill in missing fields from DLL
             $finalDescription = $dllInfo.fileDescription
-            if ([string]::IsNullOrWhiteSpace($finalDescription) -and $portMetadata.description) {
-                $finalDescription = $portMetadata.description
+            if ([string]::IsNullOrWhiteSpace($finalDescription)) {
+                if ($portMetadata.description) {
+                    $finalDescription = $portMetadata.description
+                    Write-Host "    ! $($_.Name): fileDescription empty in DLL, using port value `"$finalDescription`"" -ForegroundColor Yellow
+                } else {
+                    Write-Warning "  ! $($_.Name): fileDescription will be blank (not found in DLL or port metadata)"
+                }
             }
-            
+
             $finalProductName = $dllInfo.productName
-            if ([string]::IsNullOrWhiteSpace($finalProductName) -and $portMetadata.productName) {
-                $finalProductName = $portMetadata.productName
+            if ([string]::IsNullOrWhiteSpace($finalProductName)) {
+                if ($portMetadata.productName) {
+                    $finalProductName = $portMetadata.productName
+                    Write-Host "    ! $($_.Name): productName empty in DLL, using port value `"$finalProductName`"" -ForegroundColor Yellow
+                } else {
+                    Write-Warning "  ! $($_.Name): productName will be blank (not found in DLL or port metadata)"
+                }
             }
-            
+
             $finalCopyright = $dllInfo.copyright
-            if ([string]::IsNullOrWhiteSpace($finalCopyright) -and $portMetadata.copyright) {
-                $finalCopyright = $portMetadata.copyright
+            if ([string]::IsNullOrWhiteSpace($finalCopyright)) {
+                if ($portMetadata.copyright) {
+                    $finalCopyright = $portMetadata.copyright
+                    Write-Host "    ! $($_.Name): copyright empty in DLL, using port value `"$finalCopyright`"" -ForegroundColor Yellow
+                } else {
+                    Write-Warning "  ! $($_.Name): copyright will be omitted (not found in DLL or port metadata)"
+                }
             }
-            
-            # Always use version from vcpkg.json (versionSource) if available
-            # This ensures consistency with the port version, not what's embedded in the DLL
-            $finalFileVersion = $portMetadata.version
+
+            # Prefer DLL's own embedded fileVersion; fallback to port version
+            $finalFileVersion = $dllInfo.fileVersion
             if ([string]::IsNullOrWhiteSpace($finalFileVersion)) {
-                # Fallback to DLL metadata only if vcpkg.json doesn't have version
-                $finalFileVersion = $dllInfo.fileVersion
+                if ($portMetadata.version) {
+                    $finalFileVersion = $portMetadata.version
+                    Write-Host "    ! $($_.Name): fileVersion empty in DLL, using port value `"$finalFileVersion`"" -ForegroundColor Yellow
+                } else {
+                    Write-Warning "  ! $($_.Name): fileVersion will be blank (not found in DLL or port metadata)"
+                }
             }
-            
+
             # Normalize versions (strip 4th part if present)
+            if ($finalFileVersion -match '^\d+,') {
+                Write-Host "    ! $($_.Name): fileVersion `"$finalFileVersion`" uses comma format, normalizing to dot format" -ForegroundColor Yellow
+            }
             $finalFileVersion = Normalize-VersionNumber -Version $finalFileVersion
-            
-            $finalProductVersion = $portMetadata.version
+
+            # Prefer DLL's own embedded productVersion; fallback to port version
+            $finalProductVersion = $dllInfo.productVersion
             if ([string]::IsNullOrWhiteSpace($finalProductVersion)) {
-                # Fallback to DLL metadata only if vcpkg.json doesn't have version
-                $finalProductVersion = $dllInfo.productVersion
+                if ($portMetadata.version) {
+                    $finalProductVersion = $portMetadata.version
+                    Write-Host "    ! $($_.Name): productVersion empty in DLL, using port value `"$finalProductVersion`"" -ForegroundColor Yellow
+                } else {
+                    Write-Warning "  ! $($_.Name): productVersion will be blank (not found in DLL or port metadata)"
+                }
             }
-            
+
             # Normalize versions (strip 4th part if present)
+            if ($finalProductVersion -match '^\d+,') {
+                Write-Host "    ! $($_.Name): productVersion `"$finalProductVersion`" uses comma format, normalizing to dot format" -ForegroundColor Yellow
+            }
             $finalProductVersion = Normalize-VersionNumber -Version $finalProductVersion
             
             # Build the object conditionally including copyright


### PR DESCRIPTION
### **Description**

Fixes Windows DLL version metadata for both `ffmpeg-desktop-base` and `ffmpeg-desktop-hevc` packages (ffmpeg 7.1.2 + Ogg/Vorbis/Opus).

This PR addresses critical DLL versioning issues discovered in the initial 7.1.2--ogg release where:
- All 7 core ffmpeg DLLs incorrectly embedded the product version (7.1.2.x) instead of their library API versions
- Several DLLs had version numbers that went backwards from 7.1.1, which would break Windows installers
- Vorbis DLLs had no version information embedded at all

All issues have been fixed and verified in successful pipeline builds.

### **Problems Fixed**

**1. ffmpeg DLLs embedded wrong `fileVersion` (product version instead of library API version)**
- `ffmpeg 7.1.2-ogg` stamped all 7 core ffmpeg DLLs with `7.1.2.x` instead of their individual library versions (e.g. `61.19.102.x` for `avcodec-61.dll`)
- Root cause: `portfile.cmake` passed `--windres=rc.exe` directly, bypassing ffmpeg's `compat/windows/mswindres` wrapper; `rc.exe` has no `--version` flag so `gnu_windres` detection failed and no `.rc` files were compiled into the DLLs
- Fix: removed the `--windres` override from `portfile.cmake`; ffmpeg now auto-selects `mswindres` when `--toolchain=msvc` is used

**2. `avcodec-61.dll` version `61.19.101` < ffmpeg 7.1.1's `61.19.102`**
- Upstream ffmpeg 7.1.2 has `LIBAVCODEC_VERSION_MICRO=101`, one less than our 7.1.1 build
- The 7.1.1 build was actually supposed to have `LIBAVCODEC_VERSION_MICRO=100`, but we accidentally updated the third part of the version number instead of the fourth part in a previous build; since we can't go backwards in version number due to upstream installer issues, a patch is applied instead
- Fix: patch `libavcodec/version.h` via `1002-tsc-avcodec-fix-version-micro.patch` to bump MICRO `101` → `102`; applied in `portfile.cmake`

**3. `libmp3lame.dll` embedded `3.100` instead of `3.100.2`**
- `LAME_PATCH_VERSION=0` causes `LAME_PATCH_LEVEL_STRING` to be empty, collapsing the version string
- At some point, the third instead of the fourth part of libmp3lame's version was incremented; since libmp3lame hasn't updated since then and we only increment the fourth part between builds now, a patch is needed to avoid the version going backwards
- Fix: patch `libmp3lame/version.h` via `1001-tsc-mp3lame-fix-version-string.patch`; applied in `pre-build.ps1` (Windows only, version-guarded to `3.100`)

**4. `vorbis.dll`, `vorbisenc.dll`, `vorbisfile.dll` had no embedded version resources**
- libvorbis CMake build has no `.rc` files on Windows, so all three DLLs embedded zero version info
- Fix: added `.rc` version resource files via `1001-tsc-libvorbis-add-windows-version-resources.patch`; applied in `pre-build.ps1` (Windows only, version-guarded to `1.3.7`)
  - `vorbis.dll` → `1.3.7` (project release version)
  - `vorbisenc.dll` → `2.0.12` (libtool interface version from `configure.ac`)
  - `vorbisfile.dll` → `3.3.8` (libtool interface version from `configure.ac`)

**5. `update-version-info-json.ps1` used port metadata version instead of DLL-embedded version**
- Script previously preferred vcpkg port version over the version already embedded in the DLL
- Fix: script now prefers DLL-embedded `fileVersion`/`productVersion` first, falling back to port metadata only when the DLL has no embedded value; emits warnings on fallback

**6. `update-version-info-json.ps1` choked on comma-separated version strings**
- Some DLLs (e.g. SDL2) embed versions as `"2, 32, 10, 0"` instead of `"2.32.10.0"`
- Fix: normalize comma-separated strings to dot-separated before processing

**7. `pre-build.ps1` ran macOS-only steps unconditionally on all platforms**
- `brew install nasm` and the aom patch were not gated to macOS
- Fix: restructured `pre-build.ps1` with explicit `if (Get-IsOnMacOS)` / `if (Get-IsOnWindowsOS)` blocks

## DLL Version Comparison

Versions extracted from Windows binaries across builds:

- **ffmpeg 7.1.1**: [ffmpeg-desktop-base-7.1.1--dll-version-fix-20250521-1257](https://github.com/TechSmith/ThirdParty-Packages-vcpkg/releases/tag/ffmpeg-desktop-base-7.1.1--dll-version-fix-20250521-1257)
- **ffmpeg 7.1.2-ogg**: [ffmpeg-desktop-base-7.1.2--ogg](https://github.com/TechSmith/ThirdParty-Packages-vcpkg/releases/tag/ffmpeg-desktop-base-7.1.2--ogg)
- **ffmpeg-desktop-base-7.1.2 (build 680630)**: [ffmpeg-desktop-base-windows-x64-7.1.2.105](https://github.com/TechSmith/ThirdParty-Packages-vcpkg/releases/tag/ffmpeg-desktop-base-windows-x64-7.1.2.105)
- **ffmpeg-desktop-hevc-7.1.2 (build 680631)**: [ffmpeg-desktop-hevc-windows-x64-7.1.2.105](https://github.com/TechSmith/ThirdParty-Packages-vcpkg/releases/tag/ffmpeg-desktop-hevc-windows-x64-7.1.2.105)

| DLL Name | ffmpeg 7.1.1 | ffmpeg 7.1.2-ogg | > 7.1.1? | ffmpeg-7.1.2 (builds 680630/680631) | > 7.1.1? |
|---|---|---|---|---|------|
| aom.dll | 3.11.1 | 3.13.1.100 | ✅ | 3.13.1.105 | ✅ |
| avcodec-61.dll | 61.19.102 | 7.1.2.100 | ❌ | 61.19.102.105 | ✅ |
| avdevice-61.dll | 61.3.100.2 | 7.1.2.100 | ❌ | 61.3.100.105 | ✅ |
| avfilter-10.dll | 10.4.100.2 | 7.1.2.100 | ❌ | 10.4.100.105 | ✅ |
| avformat-61.dll | 61.7.100.2 | 7.1.2.100 | ❌ | 61.7.100.105 | ✅ |
| avutil-59.dll | 59.39.100.2 | 7.1.2.100 | ❌ | 59.39.100.105 | ✅ |
| dav1d.dll | 7.0.0.1 | 1.5.1.100 | ❌ | 7.0.0.105 | ✅ |
| libmp3lame.dll | 3.100.2.19 | 3.100.0.100 | ❌ | 3.100.2.105 | ✅ |
| ogg.dll | 1.3.5.2 | 1.3.6.100 | ✅ | 1.3.6.105 | ✅ |
| opus.dll | 1.5.2.2 | 1.5.2.100 | ✅ | 1.5.2.105 | ✅ |
| SDL2.dll | 2.32.4.1 | 2.32.10.100 | ✅ | 2.32.10.105 | ✅ |
| swresample-5.dll | 5.3.100.2 | 7.1.2.100 | ✅ | 5.3.100.105 | ✅ |
| swscale-8.dll | 8.3.100.2 | 7.1.2.100 | ❌ | 8.3.100.105 | ✅ |
| vorbis.dll | 1.3.7.2 | 1.3.7.100 | ✅ | 1.3.7.105 | ✅ |
| vorbisenc.dll | 2.0.12.2 | 1.3.7.100 | ❌ | 2.0.12.105 | ✅ |
| vorbisfile.dll | 3.3.8.2 | 1.3.7.100 | ❌ | 3.3.8.105 | ✅ |
| zlib1.dll | 1.3.1.102 | 1.3.1.100 | ❌ | 1.3.2.105 | ✅ |

> ✅ = fileVersion is numerically greater than ffmpeg 7.1.1  
> ❌ = fileVersion is numerically less than ffmpeg 7.1.1 (indicates a problem in that build)

> **swresample-5.dll note (`7.1.2.100` > `5.3.100.2`):** Numerically greater only because the wrong ffmpeg product version `7.1.2` was stamped instead of the correct library version `5.3.100`. The 7.1.2-ogg build had the wrong version scheme for all 7 core ffmpeg DLLs.

### **What do clients need to know about this PR?**

This PR fixes critical DLL version metadata issues in the ffmpeg 7.1.2--ogg release. No functional changes to the libraries themselves - only version information embedded in the DLLs has been corrected. All DLL versions are now monotonically increasing from 7.1.1, ensuring Windows installers can successfully upgrade without rollback issues.

### **How Did You Verify Quality?**
- [ ] Added Unit Tests / Unit Tests Passed
- [ ] Added Integration Tests / Integration Tests Passed 
- [x] Manually Tested ( details below )
  - [x] ThirdParty-Packages-vcpkg pipeline builds passed for both `ffmpeg-desktop-hevc` (build 680631) and `ffmpeg-desktop-base` (build 680630) on Windows and macOS
  - [x] Verified all Windows DLL fileVersion metadata using FileVersionInfo API
  - [x] Confirmed all DLL versions are greater than 7.1.1 baseline (no version rollbacks)
  - [x] Validated version-info.json regeneration script correctly extracts DLL-embedded versions
- [ ] N/A

### **Is there any documentation that needs to be updated?**
- [x] Updated relevant documentation / wiki articles to reflect changes to behavior
  - Updated README.md to fix update-version-info-json.ps1 script path and usage example
