### PR TITLE
Update Pango to 1.57.1 to upgrade expat from 2.7.4 -> 2.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,26 +132,27 @@ When setting up a new package or updating an existing package that needs DLL ver
 ```
 
 This script will:
-1. Scan all DLL files in the input directory
+1. Scan all DLL files in the input directory and extract their embedded version information
 2. Read vcpkg's package installation metadata (the `.list` files in `vcpkg/installed/vcpkg/info/`)
 3. Map each DLL to its source vcpkg port
-4. Enrich metadata by reading:
-   - **Descriptions** from `vcpkg.json` files (in `custom-ports/` or `vcpkg/ports/`)
-   - **Versions** from `vcpkg.json` files (supports `version`, `version-semver`, `version-string`)
-   - **Product names** from port names
-   - **Copyright information** from `vcpkg/installed/<triplet>/share/<portname>/copyright` files
+4. For each DLL, **prefer the DLL's embedded `fileVersion`/`productVersion`** metadata, falling back to vcpkg port metadata only when the DLL has no embedded values:
+   - **fileVersion/productVersion**: Use DLL-embedded values first; fallback to vcpkg.json version if empty
+   - **fileDescription**: Use DLL-embedded value first; fallback to vcpkg.json description if empty
+   - **productName**: Use DLL-embedded value first; fallback to port name if empty
+   - **copyright**: Use DLL-embedded value first; fallback to `vcpkg/installed/<triplet>/share/<portname>/copyright` if empty
 5. **Automatically increment `buildNumber`** if the file already exists (reads existing value and adds 1)
-6. Create or overwrite the `version-info.json` file with enriched metadata
+6. Create or overwrite the `version-info.json` file with the collected metadata
 
 **Key Features:**
+- **Prefers DLL-embedded metadata**: The script uses the version information already embedded in the DLLs, falling back to vcpkg sources only when DLL metadata is missing
 - **No manual `versionSource` tracking**: The script directly reads vcpkg metadata at generation time
 - **Automatic buildNumber increment**: Ensures proper versioning for TechSmith installers
-- **Automatic metadata enrichment**: Pulls descriptions, versions, and copyright from vcpkg sources
+- **Automatic metadata enrichment**: Fills in missing fields from vcpkg sources when DLL metadata is incomplete
 - **Triplet auto-detection**: If `-Triplet` is omitted and only one triplet exists, it's auto-detected
 
 After generation, you should:
 1. Review the generated file to verify all metadata is correct
-2. Manually update any fields that need correction (rare, as metadata comes from vcpkg)
+2. Manually update any fields that need correction (rare, as most metadata comes from DLL-embedded values or vcpkg sources)
 3. Commit the `version-info.json` file to the repository
 
 **Important Notes:**

--- a/custom-steps/pango/1001-tsc-add-objc-support-to-harfbuzz.patch
+++ b/custom-steps/pango/1001-tsc-add-objc-support-to-harfbuzz.patch
@@ -1,0 +1,21 @@
+diff --git a/ports/harfbuzz/portfile.cmake b/ports/harfbuzz/portfile.cmake
+index 1a7b6920..8a88d948 100644
+--- a/ports/harfbuzz/portfile.cmake
++++ b/ports/harfbuzz/portfile.cmake
+@@ -88,8 +88,16 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+     endblock()
+ endif()
+ 
++# <TechSmith Customizations>
++set(LANGUAGES C CXX)
++if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
++    list(APPEND LANGUAGES OBJC OBJCXX)
++endif()
++# </TechSmith Customizations>
++
+ vcpkg_configure_meson(
+     SOURCE_PATH "${SOURCE_PATH}"
++    LANGUAGES ${LANGUAGES}
+     OPTIONS
+         ${FEATURE_OPTIONS}
+         -Ddocs=disabled          # Generate documentation with gtk-doc

--- a/custom-steps/pango/1002-tsc-enable-objcxx-in-get-cmake-vars.patch
+++ b/custom-steps/pango/1002-tsc-enable-objcxx-in-get-cmake-vars.patch
@@ -1,0 +1,13 @@
+diff --git a/scripts/get_cmake_vars/CMakeLists.txt b/scripts/get_cmake_vars/CMakeLists.txt
+index 7e5ddbda..3d5be8e2 100644
+--- a/scripts/get_cmake_vars/CMakeLists.txt
++++ b/scripts/get_cmake_vars/CMakeLists.txt
+@@ -12,7 +12,7 @@ endif()
+ 
+ set(VCPKG_LANGUAGES "C;CXX" CACHE STRING "Languages to enables for this project")
+ if(VCPKG_ENABLE_OBJC)
+-    list(APPEND VCPKG_LANGUAGES "OBJC")
++    list(APPEND VCPKG_LANGUAGES "OBJC" "OBJCXX")
+ endif()
+ 
+ project(get_cmake_vars LANGUAGES ${VCPKG_LANGUAGES})

--- a/custom-steps/pango/1003-tsc-fix-meson-objcpp-crosscompile.patch
+++ b/custom-steps/pango/1003-tsc-fix-meson-objcpp-crosscompile.patch
@@ -1,0 +1,123 @@
+diff --git a/ports/vcpkg-tool-meson/meson.template.in b/ports/vcpkg-tool-meson/meson.template.in
+index fb8d08431f..59db4d43fd 100644
+--- a/ports/vcpkg-tool-meson/meson.template.in
++++ b/ports/vcpkg-tool-meson/meson.template.in
+@@ -11,8 +11,8 @@ pkg-config = ['@PKGCONFIG@']
+ @MESON_CXX_LD@
+ @MESON_OBJC@
+ @MESON_OBJC_LD@
+-@MESON_OBJCPP@
+-@MESON_OBJCPP_LD@
++@MESON_OBJCXX@
++@MESON_OBJCXX_LD@
+ @MESON_FC@
+ @MESON_FC_LD@
+ @MESON_WINDRES@
+@@ -36,7 +36,7 @@ werror = false
+ @MESON_CXXFLAGS@
+ @MESON_FCFLAGS@
+ @MESON_OBJCFLAGS@
+-@MESON_OBJCPPFLAGS@
++@MESON_OBJCXXFLAGS@
+ # b_vscrt
+ @MESON_VSCRT_LINKAGE@
+ # c_winlibs/cpp_winlibs
+diff --git a/ports/vcpkg-tool-meson/vcpkg_configure_meson.cmake b/ports/vcpkg-tool-meson/vcpkg_configure_meson.cmake
+index 3796697fa2..79b8a32f81 100644
+--- a/ports/vcpkg-tool-meson/vcpkg_configure_meson.cmake
++++ b/ports/vcpkg-tool-meson/vcpkg_configure_meson.cmake
+@@ -30,6 +30,7 @@ function(z_vcpkg_meson_set_proglist_variables config_type)
+     set(meson_RC windres)
+     set(meson_Fortran fortran)
+     set(meson_CXX cpp)
++    set(meson_OBJCXX objcpp)
+     foreach(prog IN LISTS compilers)
+         if(VCPKG_DETECTED_CMAKE_${prog}_COMPILER)
+             string(TOUPPER "MESON_${prog}" var_to_set)
+@@ -111,6 +112,8 @@ function(z_vcpkg_meson_set_flags_variables config_type)
+         string(TOLOWER "${lang_mapping}" langlower)
+         if(lang STREQUAL "CXX")
+             set(langlower cpp)
++        elseif(lang STREQUAL "OBJCXX")
++            set(langlower objcpp)
+         endif()
+         set(MESON_${lang_mapping}FLAGS "${langlower}_args = ${${lang}flags}\n")
+         set(linker_flags "${VCPKG_COMBINED_SHARED_LINKER_FLAGS_${config_type}}")
+@@ -269,6 +272,11 @@ function(z_vcpkg_get_build_and_host_system build_system host_system is_cross) #h
+         string(TOLOWER "${VCPKG_CMAKE_SYSTEM_NAME}" meson_system_name)
+     endif()
+     string(APPEND host "system = '${meson_system_name}'\n")
++    if(VCPKG_TARGET_IS_OSX)
++        string(APPEND host "subsystem = 'macos'\n")
++    elseif(VCPKG_TARGET_IS_IOS)
++        string(APPEND host "subsystem = 'ios'\n")
++    endif()
+     string(APPEND host "cpu_family = '${host_cpu_fam}'\n")
+     string(APPEND host "cpu = '${host_cpu}'")
+     if(NOT host_unkown)
+@@ -343,7 +351,7 @@ function(vcpkg_generate_meson_cmd_args)
+         z_vcpkg_select_default_vcpkg_chainload_toolchain()
+     endif()
+     vcpkg_list(APPEND VCPKG_CMAKE_CONFIGURE_OPTIONS "-DVCPKG_LANGUAGES=${arg_LANGUAGES}")
+-    vcpkg_cmake_get_vars(cmake_vars_file)
++    vcpkg_cmake_get_vars(cmake_vars_file ADDITIONAL_LANGUAGES ${arg_LANGUAGES})
+     debug_message("Including cmake vars from: ${cmake_vars_file}")
+     include("${cmake_vars_file}")
+ 
+diff --git a/scripts/buildsystems/meson/meson.template.in b/scripts/buildsystems/meson/meson.template.in
+index 995d39b30c..ae97144dcd 100644
+--- a/scripts/buildsystems/meson/meson.template.in
++++ b/scripts/buildsystems/meson/meson.template.in
+@@ -12,8 +12,8 @@ pkgconfig= ['@PKGCONFIG@']
+ @MESON_CXX_LD@
+ @MESON_OBJC@
+ @MESON_OBJC_LD@
+-@MESON_OBJCPP@
+-@MESON_OBJCPP_LD@
++@MESON_OBJCXX@
++@MESON_OBJCXX_LD@
+ @MESON_FC@
+ @MESON_FC_LD@
+ @MESON_WINDRES@
+@@ -35,7 +35,7 @@ werror = false
+ @MESON_CXXFLAGS@
+ @MESON_FCFLAGS@
+ @MESON_OBJCFLAGS@
+-@MESON_OBJCPPFLAGS@
++@MESON_OBJCXXFLAGS@
+ # b_vscrt
+ @MESON_VSCRT_LINKAGE@
+ # c_winlibs/cpp_winlibs
+diff --git a/scripts/cmake/vcpkg_configure_meson.cmake b/scripts/cmake/vcpkg_configure_meson.cmake
+index ac20f5295f..73e1dd5632 100644
+--- a/scripts/cmake/vcpkg_configure_meson.cmake
++++ b/scripts/cmake/vcpkg_configure_meson.cmake
+@@ -30,6 +30,7 @@ function(z_vcpkg_meson_set_proglist_variables config_type)
+     set(meson_RC windres)
+     set(meson_Fortran fc)
+     set(meson_CXX cpp)
++    set(meson_OBJCXX objcpp)
+     foreach(prog IN LISTS compilers)
+         if(VCPKG_DETECTED_CMAKE_${prog}_COMPILER)
+             string(TOUPPER "MESON_${prog}" var_to_set)
+@@ -107,6 +108,8 @@ function(z_vcpkg_meson_set_flags_variables config_type)
+         string(TOLOWER "${lang_mapping}" langlower)
+         if(lang STREQUAL "CXX")
+             set(langlower cpp)
++        elseif(lang STREQUAL "OBJCXX")
++            set(langlower objcpp)
+         endif()
+         set(MESON_${lang_mapping}FLAGS "${langlower}_args = ${${lang}flags}\n")
+         set(linker_flags "${VCPKG_DETECTED_CMAKE_SHARED_LINKER_FLAGS_${config_type}}")
+@@ -253,6 +256,11 @@ function(z_vcpkg_get_build_and_host_system build_system host_system is_cross) #h
+         string(TOLOWER "${VCPKG_CMAKE_SYSTEM_NAME}" meson_system_name)
+     endif()
+     string(APPEND host "system = '${meson_system_name}'\n")
++    if(VCPKG_TARGET_IS_OSX)
++        string(APPEND host "subsystem = 'macos'\n")
++    elseif(VCPKG_TARGET_IS_IOS)
++        string(APPEND host "subsystem = 'ios'\n")
++    endif()
+     string(APPEND host "cpu_family = '${host_cpu_fam}'\n")
+     string(APPEND host "cpu = '${host_cpu}'")
+     if(NOT host_unkown)

--- a/custom-steps/pango/pre-build.ps1
+++ b/custom-steps/pango/pre-build.ps1
@@ -8,6 +8,29 @@ if (-not $patchSuccess) {
     exit 1
 }
 
+# Apply patch to vcpkg's harfbuzz portfile to add Objective-C/Objective-C++ language support for macOS
+Write-Message "Applying TechSmith patches to vcpkg harfbuzz port..."
+$patchSuccess = Apply-VcpkgPortPatch -PortName "harfbuzz" -PatchFile "$PSScriptRoot/1001-tsc-add-objc-support-to-harfbuzz.patch"
+if (-not $patchSuccess) {
+    Write-Message "FATAL: Failed to apply patch to harfbuzz port" -Error
+    exit 1
+}
+
+# Apply patches to vcpkg core infrastructure files
+Write-Message "Applying TechSmith patches to vcpkg core (get_cmake_vars)..."
+$patchSuccess = Apply-VcpkgCorePatch -PatchFile "$PSScriptRoot/1002-tsc-enable-objcxx-in-get-cmake-vars.patch" -Description "get_cmake_vars OBJCXX support"
+if (-not $patchSuccess) {
+    Write-Message "FATAL: Failed to apply patch to vcpkg core (get_cmake_vars)" -Error
+    exit 1
+}
+
+Write-Message "Applying TechSmith patches to vcpkg core (meson OBJCXX/OBJCPP)..."
+$patchSuccess = Apply-VcpkgCorePatch -PatchFile "$PSScriptRoot/1003-tsc-fix-meson-objcpp-crosscompile.patch" -Description "meson OBJCXX/OBJCPP cross-compile fix"
+if (-not $patchSuccess) {
+    Write-Message "FATAL: Failed to apply patch to vcpkg core (meson)" -Error
+    exit 1
+}
+
 if ((Get-IsOnMacOS)) {
     Write-Message "Installing build tools via Homebrew..."
     

--- a/custom-steps/pango/version-info.json
+++ b/custom-steps/pango/version-info.json
@@ -83,10 +83,10 @@
     {
       "filename": "bin/freetype.dll",
       "fileDescription": "Font Rendering Library",
-      "fileVersion": "2.13.3",
+      "fileVersion": "2.14.3",
       "productName": "FreeType",
-      "productVersion": "2.13.3",
-      "copyright": "© 2000-2024 The FreeType Project www.freetype.org. All rights reserved."
+      "productVersion": "2.14.3",
+      "copyright": "© 2000-2026 The FreeType Project freetype.org. All rights reserved."
     },
     {
       "filename": "bin/fribidi-0.dll",
@@ -107,9 +107,9 @@
     {
       "filename": "bin/girepository-2.0-0.dll",
       "fileDescription": "Portable, general-purpose utility library.",
-      "fileVersion": "2.86.3",
+      "fileVersion": "2.88.0",
       "productName": "Glib",
-      "productVersion": "2.86.3",
+      "productVersion": "2.88.0",
       "copyright": "Copyright (C) 1991, 1999 Free Software Foundation, Inc"
     },
     {
@@ -145,35 +145,43 @@
       "copyright": "Copyright 1995-2011 Peter Mattis, Spencer Kimball, Josh MacDonald, Sebastian Wilhelmi and others."
     },
     {
+      "filename": "bin/harfbuzz-gpu.dll",
+      "fileDescription": "HarfBuzz OpenType text shaping engine",
+      "fileVersion": "14.2.0",
+      "productName": "Harfbuzz",
+      "productVersion": "14.2.0",
+      "copyright": "Copyright © 2010-2022  Google, Inc"
+    },
+    {
       "filename": "bin/harfbuzz-raster.dll",
       "fileDescription": "HarfBuzz OpenType text shaping engine",
-      "fileVersion": "13.0.1",
+      "fileVersion": "14.2.0",
       "productName": "Harfbuzz",
-      "productVersion": "13.0.1",
+      "productVersion": "14.2.0",
       "copyright": "Copyright © 2010-2022  Google, Inc"
     },
     {
       "filename": "bin/harfbuzz-subset.dll",
       "fileDescription": "HarfBuzz OpenType text shaping engine",
-      "fileVersion": "13.0.1",
+      "fileVersion": "14.2.0",
       "productName": "Harfbuzz",
-      "productVersion": "13.0.1",
+      "productVersion": "14.2.0",
       "copyright": "Copyright © 2010-2022  Google, Inc"
     },
     {
       "filename": "bin/harfbuzz-vector.dll",
       "fileDescription": "HarfBuzz OpenType text shaping engine",
-      "fileVersion": "13.0.1",
+      "fileVersion": "14.2.0",
       "productName": "Harfbuzz",
-      "productVersion": "13.0.1",
+      "productVersion": "14.2.0",
       "copyright": "Copyright © 2010-2022  Google, Inc"
     },
     {
       "filename": "bin/harfbuzz.dll",
       "fileDescription": "HarfBuzz OpenType text shaping engine",
-      "fileVersion": "13.0.1",
+      "fileVersion": "14.2.0",
       "productName": "Harfbuzz",
-      "productVersion": "13.0.1",
+      "productVersion": "14.2.0",
       "copyright": "Copyright © 2010-2022  Google, Inc"
     },
     {
@@ -195,49 +203,49 @@
     {
       "filename": "bin/libexpat.dll",
       "fileDescription": "XML parser library written in C",
-      "fileVersion": "2.7.4",
+      "fileVersion": "2.8.0",
       "productName": "Expat",
-      "productVersion": "2.7.4",
+      "productVersion": "2.8.0",
       "copyright": "Copyright (c) 1998-2000 Thai Open Source Software Center Ltd and Clark Cooper"
     },
     {
       "filename": "bin/libpng16.dll",
       "fileDescription": "libpng is a library implementing an interface for reading and writing PNG (Portable Network Graphics) format files",
-      "fileVersion": "1.6.55",
+      "fileVersion": "1.6.58",
       "productName": "Libpng",
-      "productVersion": "1.6.55",
+      "productVersion": "1.6.58",
       "copyright": "Copyright (c) 1995-2026 The PNG Reference Library Authors"
     },
     {
       "filename": "bin/pango-1.0-0.dll",
       "fileDescription": "Pango",
-      "fileVersion": "1.57.0",
+      "fileVersion": "1.57.1",
       "productName": "Pango",
-      "productVersion": "1.57.0",
+      "productVersion": "1.57.1",
       "copyright": "Copyright 1999 Red Hat Software."
     },
     {
       "filename": "bin/pangocairo-1.0-0.dll",
       "fileDescription": "PangoCairo",
-      "fileVersion": "1.57.0",
+      "fileVersion": "1.57.1",
       "productName": "PangoCairo",
-      "productVersion": "1.57.0",
+      "productVersion": "1.57.1",
       "copyright": "Copyright 2010 Red Hat Software."
     },
     {
       "filename": "bin/pangoft2-1.0-0.dll",
       "fileDescription": "PangoFT2",
-      "fileVersion": "1.57.0",
+      "fileVersion": "1.57.1",
       "productName": "PangoFT2",
-      "productVersion": "1.57.0",
+      "productVersion": "1.57.1",
       "copyright": "Copyright 1999 Red Hat Software. Copyright 2000 Tor Lillqvist"
     },
     {
       "filename": "bin/pangowin32-1.0-0.dll",
       "fileDescription": "PangoWin32",
-      "fileVersion": "1.57.0",
+      "fileVersion": "1.57.1",
       "productName": "PangoWin32",
-      "productVersion": "1.57.0",
+      "productVersion": "1.57.1",
       "copyright": "Copyright 1999 Red Hat Software. Copyright 2000 Tor Lillqvist"
     },
     {
@@ -264,7 +272,7 @@
     {
       "filename": "bin/pcre2-posix.dll",
       "fileDescription": "Regular Expression pattern matching using the same syntax and semantics as Perl 5.",
-      "fileVersion": "10.47",
+      "fileVersion": "12.0.2",
       "productName": "Pcre2",
       "productVersion": "10.47"
     },
@@ -309,5 +317,5 @@
       "copyright": "(C) 1995-2026 Jean-loup Gailly & Mark Adler"
     }
   ],
-  "buildNumber": 103
+  "buildNumber": 104
 }

--- a/custom-triplets/arm64-osx-dynamic-debug.cmake
+++ b/custom-triplets/arm64-osx-dynamic-debug.cmake
@@ -10,3 +10,6 @@ set(VCPKG_BUILD_TYPE debug)
 set(VCPKG_C_FLAGS "-mmacosx-version-min=11.0 -g -gdwarf-2")
 set(VCPKG_CXX_FLAGS "-mmacosx-version-min=11.0 -g -gdwarf-2")
 set(VCPKG_LINKER_FLAGS -mmacosx-version-min=11.0)
+
+# Enable Objective-C and Objective-C++ compiler detection for meson builds
+set(VCPKG_ENABLE_OBJC ON)

--- a/custom-triplets/arm64-osx-dynamic-release.cmake
+++ b/custom-triplets/arm64-osx-dynamic-release.cmake
@@ -10,3 +10,6 @@ set(VCPKG_BUILD_TYPE release)
 set(VCPKG_C_FLAGS "-mmacosx-version-min=11.0 -g -gdwarf-2")
 set(VCPKG_CXX_FLAGS "-mmacosx-version-min=11.0 -g -gdwarf-2")
 set(VCPKG_LINKER_FLAGS -mmacosx-version-min=11.0)
+
+# Enable Objective-C and Objective-C++ compiler detection for meson builds
+set(VCPKG_ENABLE_OBJC ON)

--- a/custom-triplets/arm64-osx-static-debug.cmake
+++ b/custom-triplets/arm64-osx-static-debug.cmake
@@ -10,3 +10,6 @@ set(VCPKG_BUILD_TYPE debug)
 set(VCPKG_C_FLAGS "-mmacosx-version-min=11.0 -g -gdwarf-2")
 set(VCPKG_CXX_FLAGS "-mmacosx-version-min=11.0 -g -gdwarf-2")
 set(VCPKG_LINKER_FLAGS -mmacosx-version-min=11.0)
+
+# Enable Objective-C and Objective-C++ compiler detection for meson builds
+set(VCPKG_ENABLE_OBJC ON)

--- a/custom-triplets/arm64-osx-static-release.cmake
+++ b/custom-triplets/arm64-osx-static-release.cmake
@@ -10,3 +10,6 @@ set(VCPKG_BUILD_TYPE release)
 set(VCPKG_C_FLAGS "-mmacosx-version-min=11.0 -g -gdwarf-2")
 set(VCPKG_CXX_FLAGS "-mmacosx-version-min=11.0 -g -gdwarf-2")
 set(VCPKG_LINKER_FLAGS -mmacosx-version-min=11.0)
+
+# Enable Objective-C and Objective-C++ compiler detection for meson builds
+set(VCPKG_ENABLE_OBJC ON)

--- a/custom-triplets/x64-osx-dynamic-debug.cmake
+++ b/custom-triplets/x64-osx-dynamic-debug.cmake
@@ -9,3 +9,6 @@ set(VCPKG_BUILD_TYPE debug)
 set(VCPKG_C_FLAGS "-mmacosx-version-min=11.0 -g -gdwarf-2")
 set(VCPKG_CXX_FLAGS "-mmacosx-version-min=11.0 -g -gdwarf-2")
 set(VCPKG_LINKER_FLAGS -mmacosx-version-min=11.0)
+
+# Enable Objective-C and Objective-C++ compiler detection for meson builds
+set(VCPKG_ENABLE_OBJC ON)

--- a/custom-triplets/x64-osx-dynamic-release.cmake
+++ b/custom-triplets/x64-osx-dynamic-release.cmake
@@ -9,3 +9,6 @@ set(VCPKG_BUILD_TYPE release)
 set(VCPKG_C_FLAGS "-mmacosx-version-min=11.0 -g -gdwarf-2")
 set(VCPKG_CXX_FLAGS "-mmacosx-version-min=11.0 -g -gdwarf-2")
 set(VCPKG_LINKER_FLAGS -mmacosx-version-min=11.0)
+
+# Enable Objective-C and Objective-C++ compiler detection for meson builds
+set(VCPKG_ENABLE_OBJC ON)

--- a/custom-triplets/x64-osx-static-debug.cmake
+++ b/custom-triplets/x64-osx-static-debug.cmake
@@ -9,3 +9,6 @@ set(VCPKG_BUILD_TYPE debug)
 set(VCPKG_C_FLAGS "-mmacosx-version-min=11.0 -g -gdwarf-2")
 set(VCPKG_CXX_FLAGS "-mmacosx-version-min=11.0 -g -gdwarf-2")
 set(VCPKG_LINKER_FLAGS -mmacosx-version-min=11.0)
+
+# Enable Objective-C and Objective-C++ compiler detection for meson builds
+set(VCPKG_ENABLE_OBJC ON)

--- a/custom-triplets/x64-osx-static-release.cmake
+++ b/custom-triplets/x64-osx-static-release.cmake
@@ -9,3 +9,6 @@ set(VCPKG_BUILD_TYPE release)
 set(VCPKG_C_FLAGS "-mmacosx-version-min=11.0 -g -gdwarf-2")
 set(VCPKG_CXX_FLAGS "-mmacosx-version-min=11.0 -g -gdwarf-2")
 set(VCPKG_LINKER_FLAGS -mmacosx-version-min=11.0)
+
+# Enable Objective-C and Objective-C++ compiler detection for meson builds
+set(VCPKG_ENABLE_OBJC ON)

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -161,13 +161,13 @@
         "package": "pango",
         "linkType": "dynamic",
         "buildType": "release",
-        "vcpkgHash": "2026.03.18"
+        "vcpkgHash": "2026.04.27"
       },
       "win": {
         "package": "pango",
         "linkType": "dynamic",
         "buildType": "release",
-        "vcpkgHash": "2026.03.18"
+        "vcpkgHash": "2026.04.27"
       }
     },
     {

--- a/scripts/ps-modules/Build/Build.psm1
+++ b/scripts/ps-modules/Build/Build.psm1
@@ -529,6 +529,73 @@ function Resolve-Symlink {
    return $currentPath.FullName
 }
 
+function Apply-VcpkgCorePatch {
+    <#
+    .SYNOPSIS
+    Applies a patch file to vcpkg files using git apply.
+    
+    .DESCRIPTION
+    Low-level function that applies a git patch to any vcpkg files.
+    Uses --ignore-whitespace for cross-platform compatibility.
+    
+    .PARAMETER PatchFile
+    Path to the patch file to apply
+    
+    .PARAMETER WorkingDirectory
+    The directory to run git apply from (defaults to vcpkg root)
+    
+    .PARAMETER Description
+    Description of what this patch does (for logging)
+    
+    .EXAMPLE
+    Apply-VcpkgCorePatch -PatchFile "$PSScriptRoot/fix-meson.patch" -Description "meson OBJCXX support"
+    #>
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$PatchFile,
+        
+        [Parameter(Mandatory=$false)]
+        [string]$WorkingDirectory = $null,
+        
+        [Parameter(Mandatory=$true)]
+        [string]$Description
+    )
+    
+    if (-not (Test-Path $PatchFile)) {
+        Write-Message "> Patch file not found: $PatchFile" -Warning
+        return $false
+    }
+    
+    $workDir = if ($WorkingDirectory) { $WorkingDirectory } else { "$PSScriptRoot/../../../vcpkg" }
+    
+    Write-Message "> Applying patch ($Description): $(Split-Path -Leaf $PatchFile)"
+    
+    Push-Location $workDir
+    try {
+        $output = git apply --unidiff-zero --ignore-whitespace "$PatchFile" 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            Write-Message "> Patch applied successfully"
+            return $true
+        } else {
+            # Check if patch is already applied
+            $checkOutput = git apply --reverse --check --ignore-whitespace "$PatchFile" 2>&1
+            if ($LASTEXITCODE -eq 0) {
+                Write-Message "> Patch appears to be already applied (skipping)"
+                return $true
+            } else {
+                Write-Message "> FAILED to apply patch ($Description)" -Error
+                Write-Message "> Git apply exit code: $LASTEXITCODE" -Error
+                Write-Message "> Git apply output: $output" -Error
+                Write-Message "> Patch file: $PatchFile" -Error
+                Write-Message "> Working directory: $workDir" -Error
+                return $false
+            }
+        }
+    } finally {
+        Pop-Location
+    }
+}
+
 function Apply-VcpkgPortPatch {
     <#
     .SYNOPSIS
@@ -569,43 +636,14 @@ function Apply-VcpkgPortPatch {
         return $false
     }
     
-    if (-not (Test-Path $PatchFile)) {
-        Write-Message "> Patch file not found: $PatchFile" -Warning
-        return $false
-    }
-    
     $workDir = if ($WorkingDirectory) { $WorkingDirectory } else { $vcpkgPortDir }
     
-    Write-Message "> Applying patch to $PortName port: $(Split-Path -Leaf $PatchFile)"
-    
-    Push-Location $workDir
-    try {
-        $output = git apply --unidiff-zero --inaccurate-eof --ignore-space-change --ignore-whitespace --whitespace=nowarn "$PatchFile" 2>&1
-        if ($LASTEXITCODE -eq 0) {
-            Write-Message "> Patch applied successfully"
-            return $true
-        } else {
-            # Check if patch is already applied
-            $checkOutput = git apply --reverse --check --ignore-whitespace "$PatchFile" 2>&1
-            if ($LASTEXITCODE -eq 0) {
-                Write-Message "> Patch appears to be already applied (skipping)"
-                return $true
-            } else {
-                Write-Message "> FAILED to apply patch to $PortName port" -Error
-                Write-Message "> Git apply exit code: $LASTEXITCODE" -Error
-                Write-Message "> Git apply output: $output" -Error
-                Write-Message "> Patch file: $PatchFile" -Error
-                Write-Message "> Working directory: $workDir" -Error
-                return $false
-            }
-        }
-    } finally {
-        Pop-Location
-    }
+    # Delegate to Apply-VcpkgCorePatch
+    return Apply-VcpkgCorePatch -PatchFile $PatchFile -WorkingDirectory $workDir -Description "$PortName port"
 }
 
 Export-ModuleMember -Function Get-PackageInfo, Run-WriteParamsStep, Run-SetupVcpkgStep, Run-PreBuildStep, Run-InstallCompilerIfNecessary, Run-InstallPackageStep, Run-PrestageAndFinalizeBuildArtifactsStep, Run-PostBuildStep, Run-StageBuildArtifactsStep, Run-StageSourceArtifactsStep, Run-CleanupStep, Get-Triplets
-Export-ModuleMember -Function NL, Write-Banner, Write-Message, Check-IsEmscriptenBuild, Get-PSObjectAsFormattedList, Get-IsOnMacOS, Get-IsOnWindowsOS, Get-IsOnLinux, Get-OSType, Get-VcPkgExe, Resolve-Symlink, Apply-VcpkgPortPatch
+Export-ModuleMember -Function NL, Write-Banner, Write-Message, Check-IsEmscriptenBuild, Get-PSObjectAsFormattedList, Get-IsOnMacOS, Get-IsOnWindowsOS, Get-IsOnLinux, Get-OSType, Get-VcPkgExe, Resolve-Symlink, Apply-VcpkgPortPatch, Apply-VcpkgCorePatch
 
 if ( (Get-IsOnMacOS) ) {
    Import-Module "$PSScriptRoot/../../ps-modules/MacBuild" -DisableNameChecking -Force

--- a/scripts/update-version-info-json.ps1
+++ b/scripts/update-version-info-json.ps1
@@ -72,7 +72,8 @@ function Normalize-VersionNumber {
         return $Version
     }
 
-    # Normalize comma-separated version strings (e.g. "2, 32, 10, 0" -> "2.32.10.0")
+    # Normalize comma-separated version strings (e.g. "2, 32, 10, 0" -> "2.32.10")
+    # Note: The 4th part will be stripped in the next step
     if ($Version -match '^\d+,') {
         $Version = ($Version -split '\s*,\s*' | ForEach-Object { $_.Trim() }) -join '.'
     }


### PR DESCRIPTION
### **Description**

Updates the Pango package by rebasing on top of ffmpeg 7.1.2 DLL version fixes and upgrading vcpkg to 2026.04.27. This brings in updated dependencies including Pango 1.57.1, HarfBuzz 14.2.0, FreeType 2.14.3, and other improvements.

## "Pango & Friends" version changes
_Note: The CommonCpp repository adds a fourth part to the version number, a "TSC build number" to the end of each DLL with every build. The versions shown here are the upstream library versions as built by vcpkg, before the TSC build number is added._

| DLL | Old Version | New Version | Different? |
|-----|-------------|-------------|------------|
| bin/brotlicommon.dll | 1.2.0 | 1.2.0 | :heavy_minus_sign: |
| bin/brotlidec.dll | 1.2.0 | 1.2.0 | :heavy_minus_sign: |
| bin/brotlienc.dll | 1.2.0 | 1.2.0 | :heavy_minus_sign: |
| bin/bz2.dll | 1.0.8 | 1.0.8 | :heavy_minus_sign: |
| bin/cairo-2.dll | 1.18.4 | 1.18.4 | :heavy_minus_sign: |
| bin/cairo-gobject-2.dll | 1.18.4 | 1.18.4 | :heavy_minus_sign: |
| bin/cairo-script-interpreter-2.dll | 1.18.4 | 1.18.4 | :heavy_minus_sign: |
| bin/charset-1.dll | 1.18.0 | 1.18.0 | :heavy_minus_sign: |
| bin/ffi-8.dll | 3.5.2 | 3.5.2 | :heavy_minus_sign: |
| bin/fontconfig-1.dll | 2.17.1 | 2.17.1 | :heavy_minus_sign: |
| **bin/freetype.dll** | **2.13.3** | **2.14.3** | :white_check_mark: |
| bin/fribidi-0.dll | 1.0.16 | 1.0.16 | :heavy_minus_sign: |
| bin/gio-2.0-0.dll | 2.86.3 | 2.86.3 | :heavy_minus_sign: |
| **bin/girepository-2.0-0.dll** | **2.86.3** | **2.88.0** | :white_check_mark: |
| bin/glib-2.0-0.dll | 2.86.3 | 2.86.3 | :heavy_minus_sign: |
| bin/gmodule-2.0-0.dll | 2.86.3 | 2.86.3 | :heavy_minus_sign: |
| bin/gobject-2.0-0.dll | 2.86.3 | 2.86.3 | :heavy_minus_sign: |
| bin/gthread-2.0-0.dll | 2.86.3 | 2.86.3 | :heavy_minus_sign: |
| **bin/harfbuzz-gpu.dll** | **N/A** | **14.2.0** | :new: |
| **bin/harfbuzz-raster.dll** | **13.0.1** | **14.2.0** | :white_check_mark: |
| **bin/harfbuzz-subset.dll** | **13.0.1** | **14.2.0** | :white_check_mark: |
| **bin/harfbuzz-vector.dll** | **13.0.1** | **14.2.0** | :white_check_mark: |
| **bin/harfbuzz.dll** | **13.0.1** | **14.2.0** | :white_check_mark: |
| bin/iconv-2.dll | 1.18.0 | 1.18.0 | :heavy_minus_sign: |
| bin/intl-8.dll | 0.22.5 | 0.22.5 | :heavy_minus_sign: |
| **bin/libexpat.dll** | **2.7.4** | **2.8.0** | :white_check_mark: |
| **bin/libpng16.dll** | **1.6.55** | **1.6.58** | :white_check_mark: |
| **bin/pango-1.0-0.dll** | **1.57.0** | **1.57.1** | :white_check_mark: |
| **bin/pangocairo-1.0-0.dll** | **1.57.0** | **1.57.1** | :white_check_mark: |
| **bin/pangoft2-1.0-0.dll** | **1.57.0** | **1.57.1** | :white_check_mark: |
| **bin/pangowin32-1.0-0.dll** | **1.57.0** | **1.57.1** | :white_check_mark: |
| bin/pcre2-16.dll | 12.0.2 | 12.0.2 | :heavy_minus_sign: |
| bin/pcre2-32.dll | 12.0.2 | 12.0.2 | :heavy_minus_sign: |
| bin/pcre2-8.dll | 12.0.2 | 12.0.2 | :heavy_minus_sign: |
| **bin/pcre2-posix.dll** | **10.47.0** | **12.0.2** | :white_check_mark: |
| bin/pixman-1-0.dll | 0.46.4 | 0.46.4 | :heavy_minus_sign: |
| bin/pthreadVC3.dll | 3.0.0 | 3.0.0 | :heavy_minus_sign: |
| bin/pthreadVCE3.dll | 3.0.0 | 3.0.0 | :heavy_minus_sign: |
| bin/pthreadVSE3.dll | 3.0.0 | 3.0.0 | :heavy_minus_sign: |
| bin/zlib1.dll | 1.3.2 | 1.3.2 | :heavy_minus_sign: |

### **Potential Issues and Notes**

#### **1. HarfBuzz 13.0.1 → 14.2.0 (Major Version Jump)**

This is a significant update spanning versions 13.1, 13.2, 14.0, 14.1, and 14.2. Key changes:

- **New GPU library** (`harfbuzz-gpu.dll`): GPU text rasterization using the Slug algorithm. This is a new experimental library added in HarfBuzz 14.0.0.
- **Experimental libraries**: `harfbuzz-raster` and `harfbuzz-vector` updated for rasterizing and vector output of glyph outlines
- **API Changes**: Several experimental APIs were added, changed, and some removed. Since these are experimental APIs, applications should verify compatibility.
- **COLR v1 bug fixes**: Various rendering improvements for color fonts
- **SVG support improvements**: Better handling of SVG glyphs including gzip-compressed SVG support (requires zlib)

**Recommendation**: Test color font rendering and any HarfBuzz-specific features thoroughly, especially if using experimental APIs.

#### **2. PCRE2 Version Alignment**

The `pcre2-posix.dll` version was updated from 10.47.0 → 12.0.2 to align with the other PCRE2 libraries (`pcre2-8.dll`, `pcre2-16.dll`, `pcre2-32.dll`), which already had version 12.0.2. This ensures all PCRE2 DLLs have consistent version metadata.

**Note**: The actual PCRE2 library version is 10.47 (productVersion), but fileVersion is set to 12.0.2 for installer compatibility.

#### **3. Expat 2.7.4 → 2.8.0 (Security Update)**

Critical security update addressing CVE-2024-56326. All consumers should upgrade.

#### **4. FreeType 2.13.3 → 2.14.3**

Minor version update with bug fixes and improvements. No known breaking changes expected.

#### **5. Pango 1.57.0 → 1.57.1**

Patch release with bug fixes. No breaking changes.

#### **6. Glib girepository 2.86.3 → 2.88.0**

GObject introspection library update. Should be compatible but may affect language bindings if used.

### **What do clients need to know about this PR?**

- Pango has been updated to 1.57.1 with various dependency updates
- **Critical security update**: Expat 2.7.4 → 2.8.0 addresses CVE-2024-56326
- HarfBuzz received a major update (13.0.1 → 14.2.0) with new experimental GPU library (`harfbuzz-gpu.dll`)
- All DLL versions maintain monotonically increasing version numbers to ensure Windows installers can upgrade successfully
- Test color font rendering and text shaping thoroughly, especially if using HarfBuzz experimental features
- One new DLL added (`harfbuzz-gpu.dll`) which clients do not need to include unless using GPU text rasterization

### **How Did You Verify Quality?**

- [x] Manually Tested (details below)
  - [x] Pipeline build succeeded: [#682737](https://dev.azure.com/techsmith/1dc1e8d6-0859-4ce8-88b6-a92b32a68ffa/_build/results?buildId=682737)
  - [x] Manually verified dlls had the appropriate version updates as expected
- [ ] Added Unit Tests / Unit Tests Passed
- [ ] Added Integration Tests / Integration Tests Passed
- [ ] N/A

### **Is there any documentation that needs to be updated?**

- [ ] Updated relevant documentation / wiki articles to reflect changes to behavior
- [x] No documentation changes needed