### PR TITLE
Update Mac check to work on MacOS Tahoe

### DIFF
--- a/scripts/ps-modules/Util/Util.psm1
+++ b/scripts/ps-modules/Util/Util.psm1
@@ -44,6 +44,9 @@ function Get-IsOnWindowsOS {
 }
 
 function Get-IsOnMacOS {
+    if ($IsMacOS) {
+        return $true
+    }
     if ($PSVersionTable.OS -like '*Darwin*') {
         return $true
     }


### PR DESCRIPTION
`$PSVersionTable.OS` doesn't contain "Darwin" in Tahoe 26.5.1