### PR TITLE
Defined vcpkgHash for openssl

### DIFF
--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -152,7 +152,8 @@
       "win": {
         "package": "openssl",
         "linkType": "static",
-        "buildType": "release"
+        "buildType": "release",
+        "vcpkgHash": "2026.06.24"
       }
     },
     {

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -147,7 +147,8 @@
       "mac": {
         "package": "openssl",
         "linkType": "static",
-        "buildType": "release"
+        "buildType": "release",
+        "vcpkgHash": "2026.06.24"
       },
       "win": {
         "package": "openssl",


### PR DESCRIPTION
CommonCpp PR:
- https://github.com/TechSmith/CommonCpp/pull/7685

This PR adds the vcpkgHash for OpenSSL (`2026.06.24`) for Windows as a part of updating the package to version `3.6.3` from `3.3.2`.