### PR TITLE
Make pipeline builds GitHub "prerelease" builds by default, with unique tag

### DIFF
--- a/.pipelines/build-package-preconfigured.yml
+++ b/.pipelines/build-package-preconfigured.yml
@@ -40,7 +40,7 @@ parameters:
   default: true
 
 - name: isReleaseBuild
-  displayName: "Publish as final GitHub release build (unchecked: publishes as a GitHub pre-release and appends --prerelease-YYYYMMDD-HHmmss)"
+  displayName: "Publish as final GitHub release build (unchecked: publishes as a GitHub pre-release and appends --prerelease-YYYYMMDD-HHmmssZ-BuildId)"
   type: boolean
   default: false
 

--- a/.pipelines/build-package-preconfigured.yml
+++ b/.pipelines/build-package-preconfigured.yml
@@ -39,6 +39,11 @@ parameters:
   type: boolean
   default: true
 
+- name: isReleaseBuild
+  displayName: Publish as final GitHub release build (unchecked: publishes as a GitHub pre-release and appends --prerelease-YYYYMMDD-HHmmss)
+  type: boolean
+  default: false
+
 - name: appendStringToGitHubRelease
   displayName: Append a string to a GitHub release (If "20240401" specified, then "somepackage-1.2.3" would become "somepackage-1.2.3--20240401")
   type: string
@@ -51,4 +56,5 @@ stages:
     publishToPipelineArtifacts: true
     publishToGitHubRelease: ${{ parameters.publishToGitHubRelease }}
     appendStringToGitHubRelease: ${{parameters.appendStringToGitHubRelease}}
+    isReleaseBuild: ${{ parameters.isReleaseBuild }}
     isPreconfiguredBuild: true

--- a/.pipelines/build-package-preconfigured.yml
+++ b/.pipelines/build-package-preconfigured.yml
@@ -40,7 +40,7 @@ parameters:
   default: true
 
 - name: isReleaseBuild
-  displayName: Publish as final GitHub release build (unchecked: publishes as a GitHub pre-release and appends --prerelease-YYYYMMDD-HHmmss)
+  displayName: "Publish as final GitHub release build (unchecked: publishes as a GitHub pre-release and appends --prerelease-YYYYMMDD-HHmmss)"
   type: boolean
   default: false
 

--- a/.pipelines/build-package-preconfigured.yml
+++ b/.pipelines/build-package-preconfigured.yml
@@ -39,7 +39,7 @@ parameters:
   type: boolean
   default: true
 
-- name: isReleaseBuild
+- name: publishAsFinalRelease
   displayName: "Publish as final GitHub release build (unchecked: publishes as a GitHub pre-release and appends --prerelease-YYYYMMDD-HHmmssZ-BuildId)"
   type: boolean
   default: false
@@ -56,5 +56,5 @@ stages:
     publishToPipelineArtifacts: true
     publishToGitHubRelease: ${{ parameters.publishToGitHubRelease }}
     appendStringToGitHubRelease: ${{parameters.appendStringToGitHubRelease}}
-    isReleaseBuild: ${{ parameters.isReleaseBuild }}
+    publishAsFinalRelease: ${{ parameters.publishAsFinalRelease }}
     isPreconfiguredBuild: true

--- a/.pipelines/templates/build.yml
+++ b/.pipelines/templates/build.yml
@@ -30,7 +30,7 @@ parameters:
   default: false
 
 - name: isReleaseBuild
-  displayName: Publish as final GitHub release build (unchecked: publishes as a GitHub pre-release and appends --prerelease-YYYYMMDD-HHmmss)
+  displayName: "Publish as final GitHub release build (unchecked: publishes as a GitHub pre-release and appends --prerelease-YYYYMMDD-HHmmss)"
   type: boolean
   default: false
 

--- a/.pipelines/templates/build.yml
+++ b/.pipelines/templates/build.yml
@@ -29,6 +29,11 @@ parameters:
   type: boolean
   default: false
 
+- name: isReleaseBuild
+  displayName: Publish as final GitHub release build (unchecked: publishes as a GitHub pre-release and appends --prerelease-YYYYMMDD-HHmmss)
+  type: boolean
+  default: false
+
 - name: appendStringToGitHubRelease
   displayName: Append a string to a GitHub release (If "20240401" specified, then "somepackage-1.2.3" would become "somepackage-1.2.3--20240401")
   type: string
@@ -212,6 +217,12 @@ stages:
           if( $gitReleaseTagSuffix -ne "") {
              $gitReleaseTagName += "--$gitReleaseTagSuffix"
           }
+          $isPreconfiguredBuild = "${{ parameters.isPreconfiguredBuild }}" -eq "true"
+          $isReleaseBuild = "${{ parameters.isReleaseBuild }}" -eq "true"
+          if ($isPreconfiguredBuild -and -not $isReleaseBuild) {
+             $currentDateTime = Get-Date -Format "yyyyMMdd-HHmmss"
+             $gitReleaseTagName += "--prerelease-$currentDateTime"
+          }
           Write-Host "##vso[task.setvariable variable=gitReleaseTagName]$gitReleaseTagName"
           Write-Host "##vso[task.setvariable variable=gitReleaseNotes]$gitReleaseNotes"
 
@@ -230,7 +241,7 @@ stages:
           $(gitReleaseNotes)
         addChangeLog: false
         isDraft: false
-        isPreRelease: false
+        isPreRelease: ${{ and(eq(parameters.isPreconfiguredBuild, true), eq(parameters.isReleaseBuild, false)) }}
         assets: |
           $(Build.ArtifactStagingDirectory)/*
       condition: and(succeeded(), ${{ parameters.publishToGitHubRelease }})

--- a/.pipelines/templates/build.yml
+++ b/.pipelines/templates/build.yml
@@ -29,7 +29,7 @@ parameters:
   type: boolean
   default: false
 
-- name: isReleaseBuild
+- name: publishAsFinalRelease
   displayName: "Publish as final GitHub release build (unchecked: publishes as a GitHub pre-release and appends --prerelease-YYYYMMDD-HHmmssZ-BuildId)"
   type: boolean
   default: false
@@ -218,8 +218,8 @@ stages:
              $gitReleaseTagName += "--$gitReleaseTagSuffix"
           }
           $isPreconfiguredBuild = "${{ parameters.isPreconfiguredBuild }}" -eq "true"
-          $isReleaseBuild = "${{ parameters.isReleaseBuild }}" -eq "true"
-          if ($isPreconfiguredBuild -and -not $isReleaseBuild) {
+          $publishAsFinalRelease = "${{ parameters.publishAsFinalRelease }}" -eq "true"
+          if ($isPreconfiguredBuild -and -not $publishAsFinalRelease) {
              $utcDateTime = (Get-Date).ToUniversalTime().ToString("yyyyMMdd-HHmmssZ")
              $buildId = "$(Build.BuildId)".Trim()
              $gitReleaseTagName += "--prerelease-$utcDateTime-$buildId"
@@ -242,7 +242,7 @@ stages:
           $(gitReleaseNotes)
         addChangeLog: false
         isDraft: false
-        isPreRelease: ${{ and(eq(parameters.isPreconfiguredBuild, true), eq(parameters.isReleaseBuild, false)) }}
+        isPreRelease: ${{ and(eq(parameters.isPreconfiguredBuild, true), eq(parameters.publishAsFinalRelease, false)) }}
         assets: |
           $(Build.ArtifactStagingDirectory)/*
       condition: and(succeeded(), ${{ parameters.publishToGitHubRelease }})

--- a/.pipelines/templates/build.yml
+++ b/.pipelines/templates/build.yml
@@ -30,7 +30,7 @@ parameters:
   default: false
 
 - name: isReleaseBuild
-  displayName: "Publish as final GitHub release build (unchecked: publishes as a GitHub pre-release and appends --prerelease-YYYYMMDD-HHmmss)"
+  displayName: "Publish as final GitHub release build (unchecked: publishes as a GitHub pre-release and appends --prerelease-YYYYMMDD-HHmmssZ-BuildId)"
   type: boolean
   default: false
 
@@ -220,8 +220,9 @@ stages:
           $isPreconfiguredBuild = "${{ parameters.isPreconfiguredBuild }}" -eq "true"
           $isReleaseBuild = "${{ parameters.isReleaseBuild }}" -eq "true"
           if ($isPreconfiguredBuild -and -not $isReleaseBuild) {
-             $currentDateTime = Get-Date -Format "yyyyMMdd-HHmmss"
-             $gitReleaseTagName += "--prerelease-$currentDateTime"
+             $utcDateTime = (Get-Date).ToUniversalTime().ToString("yyyyMMdd-HHmmssZ")
+             $buildId = "$(Build.BuildId)".Trim()
+             $gitReleaseTagName += "--prerelease-$utcDateTime-$buildId"
           }
           Write-Host "##vso[task.setvariable variable=gitReleaseTagName]$gitReleaseTagName"
           Write-Host "##vso[task.setvariable variable=gitReleaseNotes]$gitReleaseNotes"

--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ This pipeline does the following:
 | --- | --- | --- |
 | `Package to install` | Chooses the preconfigured package to build and publish. The package metadata determines the base GitHub tag name format (`<packageName>-<version>`). | _(Required)_ |
 | `Publish built package artifacts to a tagged release in the GitHub repo` | Enables/disables publishing artifacts to a GitHub release. | `true` |
-| `Publish as final GitHub release build (unchecked: publishes as a GitHub pre-release and appends --prerelease-YYYYMMDD-HHmmss)` | If checked, publishes a normal GitHub release and does not append the prerelease suffix. If unchecked, publishes as a GitHub pre-release and appends `--prerelease-YYYYMMDD-HHmmss`. | `false` _(unchecked)_ |
+| `Publish as final GitHub release build (unchecked: publishes as a GitHub pre-release and appends --prerelease-YYYYMMDD-HHmmssZ-BuildId)` | If checked, publishes a normal GitHub release and does not append the prerelease suffix. If unchecked, publishes as a GitHub pre-release and appends `--prerelease-YYYYMMDD-HHmmssZ-BuildId`. | `false` _(unchecked)_ |
 | `Append a string to a GitHub release` | Appends `--<your-value>` to the package tag (for example, `somepackage-1.2.3--myfeature`). If prerelease mode is also used, this append-string is added first, then prerelease suffix. | _(Blank)_ |
 
 Examples:
 - Final release: `somepackage-1.2.3`
 - Final release with append-string: `somepackage-1.2.3--myfeature`
-- Prerelease (default): `somepackage-1.2.3--prerelease-YYYYMMDD-HHmmss`
-- Prerelease with append-string: `somepackage-1.2.3--myfeature--prerelease-YYYYMMDD-HHmmss`
+- Prerelease (default): `somepackage-1.2.3--prerelease-YYYYMMDD-HHmmssZ-BuildId`
+- Prerelease with append-string: `somepackage-1.2.3--myfeature--prerelease-YYYYMMDD-HHmmssZ-BuildId`
 
 ### Pipeline: "[Build Package (custom)](https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_build?definitionId=790)"
 This pipeline is for use when testing out building a new package.  Artifacts from this pipeline should never be shipped to customers.  When you finish testing using this pipeline, you must configure the "[Build Package (preconfigured)](https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_build?definitionId=789)" pipeline to contain your new package with its custom build options and expose it as a new package that a user can choose to build from that pipeline.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ This pipeline does the following:
    - All the binary artifacts for all libraries built for this package
 8. Creates a GitHub release in this repo with the source and binary artifacts for the built package in [TechSmith/ThirdParty-Packages-vcpkg/releases](https://github.com/TechSmith/ThirdParty-Packages-vcpkg/releases)
 
+#### Pipeline Options
+
+| Parameter | What it does | Default |
+| --- | --- | --- |
+| `Package to install` | Chooses the preconfigured package to build and publish. The package metadata determines the base GitHub tag name format (`<packageName>-<version>`). | _(Required)_ |
+| `Publish built package artifacts to a tagged release in the GitHub repo` | Enables/disables publishing artifacts to a GitHub release. | `true` |
+| `Publish as final GitHub release build (unchecked: publishes as a GitHub pre-release and appends --prerelease-YYYYMMDD-HHmmss)` | If checked, publishes a normal GitHub release and does not append the prerelease suffix. If unchecked, publishes as a GitHub pre-release and appends `--prerelease-YYYYMMDD-HHmmss`. | `false` _(unchecked)_ |
+| `Append a string to a GitHub release` | Appends `--<your-value>` to the package tag (for example, `somepackage-1.2.3--myfeature`). If prerelease mode is also used, this append-string is added first, then prerelease suffix. | _(Blank)_ |
+
+Examples:
+- Final release: `somepackage-1.2.3`
+- Final release with append-string: `somepackage-1.2.3--myfeature`
+- Prerelease (default): `somepackage-1.2.3--prerelease-YYYYMMDD-HHmmss`
+- Prerelease with append-string: `somepackage-1.2.3--myfeature--prerelease-YYYYMMDD-HHmmss`
+
 ### Pipeline: "[Build Package (custom)](https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_build?definitionId=790)"
 This pipeline is for use when testing out building a new package.  Artifacts from this pipeline should never be shipped to customers.  When you finish testing using this pipeline, you must configure the "[Build Package (preconfigured)](https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_build?definitionId=789)" pipeline to contain your new package with its custom build options and expose it as a new package that a user can choose to build from that pipeline.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This pipeline does the following:
 | --- | --- | --- |
 | `Package to install` | Chooses the preconfigured package to build and publish. The package metadata determines the base GitHub tag name format (`<packageName>-<version>`). | _(Required)_ |
 | `Publish built package artifacts to a tagged release in the GitHub repo` | Enables/disables publishing artifacts to a GitHub release. | `true` |
-| `Publish as final GitHub release build (unchecked: publishes as a GitHub pre-release and appends --prerelease-YYYYMMDD-HHmmssZ-BuildId)` | If checked, publishes a normal GitHub release and does not append the prerelease suffix. If unchecked, publishes as a GitHub pre-release and appends `--prerelease-YYYYMMDD-HHmmssZ-BuildId`. | `false` _(unchecked)_ |
+| `Publish as final GitHub release build (unchecked: publishes as a GitHub pre-release and appends --prerelease-YYYYMMDD-HHmmssZ-BuildId)` (`publishAsFinalRelease`) | If checked, publishes a normal GitHub release and does not append the prerelease suffix. If unchecked, publishes as a GitHub pre-release and appends `--prerelease-YYYYMMDD-HHmmssZ-BuildId`. | `false` _(unchecked)_ |
 | `Append a string to a GitHub release` | Appends `--<your-value>` to the package tag (for example, `somepackage-1.2.3--myfeature`). If prerelease mode is also used, this append-string is added first, then prerelease suffix. | _(Blank)_ |
 
 Examples:


### PR DESCRIPTION
### **Description**

Updates the preconfigured package pipeline so GitHub publishing defaults to prerelease output and uses an explicit final-release toggle.

**Key changes:**
- Adds `publishAsFinalRelease` checkbox to preconfigured pipeline UI (`default: false` / unchecked)
- Labels option as **Publish as final GitHub release build (unchecked: publishes as a GitHub pre-release and appends --prerelease-YYYYMMDD-HHmmssZ-BuildId)**
- Keeps option order with `publishAsFinalRelease` listed before `appendStringToGitHubRelease`
- When unchecked, appends `--prerelease-YYYYMMDD-HHmmssZ-BuildId` to the GitHub tag
- Uses UTC timestamp + Azure DevOps BuildId in prerelease suffix for uniqueness
- When checked, publishes a normal GitHub release with no prerelease suffix
- Sets GitHub `isPreRelease` from the same condition for consistent release metadata
- Scopes prerelease behavior to preconfigured builds; custom pipeline flow remains unchanged
- Updates `README.md` with a `Pipeline Options` table and examples for release/prerelease tag formats

### **What do clients need to know about this PR?**

- Preconfigured builds now default to GitHub prerelease publishing behavior.
- To publish a final release, check **Publish as final GitHub release build**.
- **Append a string to a GitHub release** appends `--<value>` before the prerelease suffix when both are used.
- Prerelease tags now include UTC timestamp and BuildId: `--prerelease-YYYYMMDD-HHmmssZ-BuildId`.
- Final and prerelease examples are documented in `README.md` under preconfigured pipeline options.
- No package build logic changed; this PR changes pipeline release metadata/tagging behavior and docs.

### **How Did You Verify Quality?**

- [x] Manually Tested (details below)
  - [x] In Azure DevOps, selected branch `feature/release-build-checkbox` in [Build Package (preconfigured)](https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_build?definitionId=789) before running validation
  - [x] Verified **Publish as final GitHub release build (unchecked: publishes as a GitHub pre-release and appends --prerelease-YYYYMMDD-HHmmssZ-BuildId)** defaults to unchecked
  - [x] Verified **Publish as final GitHub release build (unchecked: publishes as a GitHub pre-release and appends --prerelease-YYYYMMDD-HHmmssZ-BuildId)** appears above **Append a string to a GitHub release**
  - [x] Verified [custom pipeline](https://dev.azure.com/techsmith/ThirdParty-Packages-vcpkg/_build?definitionId=790) flow options are the same as before, when selecting branch `feature/release-build-checkbox`
  - [x] Verified `README.md` documentation matches option names, defaults, and tag examples
  - [x] Ran tinyxml validation with defaults (Build `714895`): https://dev.azure.com/techsmith/1dc1e8d6-0859-4ce8-88b6-a92b32a68ffa/_build/results?buildId=714895
    - [x] Confirm pipeline result is **Succeeded** and all matrix jobs (win/mac/linux/wasm) completed
    - [x] Confirm GitHub release tag matches `<package>-<version>--prerelease-<UTC timestamp>Z-<BuildId>`
    - [x] Confirm GitHub release is marked **Pre-release**
  - [x] Ran tinyxml validation with **Append a string to a GitHub release** = `testfeature` (Build `714896`): https://dev.azure.com/techsmith/1dc1e8d6-0859-4ce8-88b6-a92b32a68ffa/_build/results?buildId=714896
    - [x] Confirm pipeline result is **Succeeded** and all matrix jobs (win/mac/linux/wasm) completed
    - [x] Confirm GitHub release tag contains `--testfeature` before prerelease suffix
    - [x] Confirm GitHub release is marked **Pre-release**
  - [x] Ran tinyxml validation with **Publish as final GitHub release build** checked (Build `714897`): https://dev.azure.com/techsmith/1dc1e8d6-0859-4ce8-88b6-a92b32a68ffa/_build/results?buildId=714897
    - [x] Confirm pipeline result is **Succeeded** and all matrix jobs (win/mac/linux/wasm) completed
    - [x] Confirm GitHub release tag matches `<package>-<version>` (no append string, no prerelease suffix)
    - [x] Confirm GitHub release is **not** marked Pre-release
  - [x] Ran tinyxml validation with both **Append a string to a GitHub release** = `testfeature` and **Publish as final GitHub release build** checked (Build `714898`): https://dev.azure.com/techsmith/1dc1e8d6-0859-4ce8-88b6-a92b32a68ffa/_build/results?buildId=714898
    - [x] Confirm pipeline result is **Succeeded** and all matrix jobs (win/mac/linux/wasm) completed
    - [x] Confirm GitHub release tag matches `<package>-<version>--testfeature` (no prerelease suffix)
    - [x] Confirm GitHub release is **not** marked Pre-release
- [ ] Added Unit Tests / Unit Tests Passed
- [ ] Added Integration Tests / Integration Tests Passed

### **Is there any documentation that needs to be updated?**

- [x] Updated relevant documentation / wiki articles to reflect changes to behavior
  - Updated `README.md` with preconfigured pipeline option table and tag format examples




