### PR TITLE
Add DLL versioning for Dawn

### DIFF
--- a/custom-steps/dawn/post-build.ps1
+++ b/custom-steps/dawn/post-build.ps1
@@ -1,0 +1,17 @@
+param (
+    [Parameter(Mandatory=$true)][string]$BuildArtifactsPath,
+    [Parameter(Mandatory=$false)][string]$PackageAndFeatures,
+    [Parameter(Mandatory=$false)][string]$LinkType,
+    [Parameter(Mandatory=$false)][string]$BuildType,
+    [Parameter(Mandatory=$false)][string]$ModulesRoot,
+    [Parameter(Mandatory=$false)][string[]]$Triplets
+)
+
+$moduleName = "Build"
+if(-not (Get-Module -Name $moduleName)) {
+    Import-Module "$ModulesRoot/$moduleName" -Force -DisableNameChecking
+}
+
+if((Get-IsOnWindowsOS)) {
+    Update-VersionInfoForDlls -buildArtifactsPath $BuildArtifactsPath -versionInfoJsonPath "$PSScriptRoot/version-info.json"
+}

--- a/custom-steps/dawn/version-info.json
+++ b/custom-steps/dawn/version-info.json
@@ -4,7 +4,7 @@
     {
       "filename": "bin/webgpu_dawn.dll",
       "fileDescription": "Dawn is an open-source and cross-platform implementation of the WebGPU standard.",
-      "fileVersion": "20260410.140140",
+      "fileVersion": "2026.4.10",
       "productName": "Dawn",
       "productVersion": "20260410.140140",
       "copyright": "Copyright 2017-2023 The Dawn & Tint Authors"

--- a/custom-steps/dawn/version-info.json
+++ b/custom-steps/dawn/version-info.json
@@ -1,0 +1,13 @@
+{
+  "buildNumber": 100,
+  "files": [
+    {
+      "filename": "bin/webgpu_dawn.dll",
+      "fileDescription": "Dawn is an open-source and cross-platform implementation of the WebGPU standard.",
+      "fileVersion": "20260410.140140",
+      "productName": "Dawn",
+      "productVersion": "20260410.140140",
+      "copyright": "Copyright 2017-2023 The Dawn & Tint Authors"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Add Windows version-resource stamping for Dawn's `webgpu_dawn.dll`.

- Add `custom-steps/dawn/version-info.json` for `bin/webgpu_dawn.dll`.
- Add a Windows-only Dawn post-build hook that invokes `Update-VersionInfoForDlls` with that metadata.
- Stamp Dawn metadata:
  - `FileDescription`: `Dawn is an open-source and cross-platform implementation of the WebGPU standard.`
  - `FileVersion`: `2026.4.10` with repository build number `100`
  - `ProductName`: `Dawn`
  - `ProductVersion`: `20260410.140140`
  - `LegalCopyright`: `Copyright 2017-2023 The Dawn & Tint Authors`

`FileVersion` uses date-only components so the final Windows file version remains valid when the build number is appended as its fourth numeric component. `ProductVersion` retains Dawn's upstream timestamp.

## Validation

- [x] Built `dawn` locally on Windows with `./build-package.ps1 -PackageName dawn`.
- [x] Generated and reviewed `version-info.json` with `./scripts/update-version-info-json.ps1` against `x64-windows-static-md`.
- [x] Confirmed the generator maps `webgpu_dawn.dll` to `custom-ports/dawn/vcpkg.json` and reads the installed upstream copyright.
- [x] PowerShell parse check passed for `custom-steps/dawn/post-build.ps1`.
- [x] Ran the post-build hook against a locally built `webgpu_dawn.dll` and verified all stamped fields above.
