### PR TITLE
Add Azure C++ SDK

### DIFF
--- a/.pipelines/build-package-preconfigured.yml
+++ b/.pipelines/build-package-preconfigured.yml
@@ -10,6 +10,11 @@ parameters:
   displayName: Package to install (builds as a dynamic library, unless otherwise specified)
   type: string
   values:
+  - azure-core
+  - azure-identity
+  - azure-keyvault-keys
+  - azure-keyvault-secrets
+  - azure-storage-blobs
   - buildcache
   - dawn
   - ffmpeg-cloud-gpl

--- a/.pipelines/build-package-preconfigured.yml
+++ b/.pipelines/build-package-preconfigured.yml
@@ -10,11 +10,10 @@ parameters:
   displayName: Package to install (builds as a dynamic library, unless otherwise specified)
   type: string
   values:
-  - azure-core
   - azure-identity
   - azure-keyvault-keys
   - azure-keyvault-secrets
-  - azure-storage-blobs
+  - azure-storage
   - buildcache
   - dawn
   - ffmpeg-cloud-gpl

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -465,33 +465,6 @@
       }
     },
     {
-      "name": "azure-core",
-      "mac": {
-        "package": "azure-core-cpp",
-        "linkType": "static",
-        "buildType": "release",
-        "publish": {
-          "include": true,
-          "lib": true,
-          "bin": true,
-          "share": true,
-          "tools": true
-        }
-      },
-      "win": {
-        "package": "azure-core-cpp",
-        "linkType": "static",
-        "buildType": "release",
-        "publish": {
-          "include": true,
-          "lib": true,
-          "bin": true,
-          "share": true,
-          "tools": true
-        }
-      }
-    },
-    {
       "name": "azure-identity",
       "mac": {
         "package": "azure-identity-cpp",
@@ -502,7 +475,7 @@
           "lib": true,
           "bin": true,
           "share": true,
-          "tools": true
+          "tools": false
         }
       },
       "win": {
@@ -514,7 +487,7 @@
           "lib": true,
           "bin": true,
           "share": true,
-          "tools": true
+          "tools": false
         }
       }
     },
@@ -529,7 +502,7 @@
           "lib": true,
           "bin": true,
           "share": true,
-          "tools": true
+          "tools": false
         }
       },
       "win": {
@@ -541,7 +514,7 @@
           "lib": true,
           "bin": true,
           "share": true,
-          "tools": true
+          "tools": false
         }
       }
     },
@@ -556,7 +529,7 @@
           "lib": true,
           "bin": true,
           "share": true,
-          "tools": true
+          "tools": false
         }
       },
       "win": {
@@ -568,12 +541,12 @@
           "lib": true,
           "bin": true,
           "share": true,
-          "tools": true
+          "tools": false
         }
       }
     },
     {
-      "name": "azure-storage-blobs",
+      "name": "azure-storage",
       "mac": {
         "package": "azure-storage-blobs-cpp",
         "linkType": "static",
@@ -583,7 +556,7 @@
           "lib": true,
           "bin": true,
           "share": true,
-          "tools": true
+          "tools": false
         }
       },
       "win": {
@@ -595,7 +568,7 @@
           "lib": true,
           "bin": true,
           "share": true,
-          "tools": true
+          "tools": false
         }
       }
     }

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -489,6 +489,18 @@
           "share": true,
           "tools": false
         }
+      },
+      "linux": {
+        "package": "azure-identity-cpp",
+        "linkType": "static",
+        "buildType": "release",
+        "publish": {
+          "include": true,
+          "lib": true,
+          "bin": true,
+          "share": true,
+          "tools": false
+        }
       }
     },
     {
@@ -506,6 +518,18 @@
         }
       },
       "win": {
+        "package": "azure-security-keyvault-keys-cpp",
+        "linkType": "static",
+        "buildType": "release",
+        "publish": {
+          "include": true,
+          "lib": true,
+          "bin": true,
+          "share": true,
+          "tools": false
+        }
+      },
+      "linux": {
         "package": "azure-security-keyvault-keys-cpp",
         "linkType": "static",
         "buildType": "release",
@@ -543,6 +567,18 @@
           "share": true,
           "tools": false
         }
+      },
+      "linux": {
+        "package": "azure-security-keyvault-secrets-cpp",
+        "linkType": "static",
+        "buildType": "release",
+        "publish": {
+          "include": true,
+          "lib": true,
+          "bin": true,
+          "share": true,
+          "tools": false
+        }
       }
     },
     {
@@ -560,6 +596,18 @@
         }
       },
       "win": {
+        "package": "azure-storage-blobs-cpp",
+        "linkType": "static",
+        "buildType": "release",
+        "publish": {
+          "include": true,
+          "lib": true,
+          "bin": true,
+          "share": true,
+          "tools": false
+        }
+      },
+      "linux": {
         "package": "azure-storage-blobs-cpp",
         "linkType": "static",
         "buildType": "release",

--- a/preconfigured-packages.json
+++ b/preconfigured-packages.json
@@ -463,6 +463,141 @@
         "buildType": "release",
         "customTriplet": "wasm32-emscripten-static"
       }
+    },
+    {
+      "name": "azure-core",
+      "mac": {
+        "package": "azure-core-cpp",
+        "linkType": "static",
+        "buildType": "release",
+        "publish": {
+          "include": true,
+          "lib": true,
+          "bin": true,
+          "share": true,
+          "tools": true
+        }
+      },
+      "win": {
+        "package": "azure-core-cpp",
+        "linkType": "static",
+        "buildType": "release",
+        "publish": {
+          "include": true,
+          "lib": true,
+          "bin": true,
+          "share": true,
+          "tools": true
+        }
+      }
+    },
+    {
+      "name": "azure-identity",
+      "mac": {
+        "package": "azure-identity-cpp",
+        "linkType": "static",
+        "buildType": "release",
+        "publish": {
+          "include": true,
+          "lib": true,
+          "bin": true,
+          "share": true,
+          "tools": true
+        }
+      },
+      "win": {
+        "package": "azure-identity-cpp",
+        "linkType": "static",
+        "buildType": "release",
+        "publish": {
+          "include": true,
+          "lib": true,
+          "bin": true,
+          "share": true,
+          "tools": true
+        }
+      }
+    },
+    {
+      "name": "azure-keyvault-keys",
+      "mac": {
+        "package": "azure-security-keyvault-keys-cpp",
+        "linkType": "static",
+        "buildType": "release",
+        "publish": {
+          "include": true,
+          "lib": true,
+          "bin": true,
+          "share": true,
+          "tools": true
+        }
+      },
+      "win": {
+        "package": "azure-security-keyvault-keys-cpp",
+        "linkType": "static",
+        "buildType": "release",
+        "publish": {
+          "include": true,
+          "lib": true,
+          "bin": true,
+          "share": true,
+          "tools": true
+        }
+      }
+    },
+    {
+      "name": "azure-keyvault-secrets",
+      "mac": {
+        "package": "azure-security-keyvault-secrets-cpp",
+        "linkType": "static",
+        "buildType": "release",
+        "publish": {
+          "include": true,
+          "lib": true,
+          "bin": true,
+          "share": true,
+          "tools": true
+        }
+      },
+      "win": {
+        "package": "azure-security-keyvault-secrets-cpp",
+        "linkType": "static",
+        "buildType": "release",
+        "publish": {
+          "include": true,
+          "lib": true,
+          "bin": true,
+          "share": true,
+          "tools": true
+        }
+      }
+    },
+    {
+      "name": "azure-storage-blobs",
+      "mac": {
+        "package": "azure-storage-blobs-cpp",
+        "linkType": "static",
+        "buildType": "release",
+        "publish": {
+          "include": true,
+          "lib": true,
+          "bin": true,
+          "share": true,
+          "tools": true
+        }
+      },
+      "win": {
+        "package": "azure-storage-blobs-cpp",
+        "linkType": "static",
+        "buildType": "release",
+        "publish": {
+          "include": true,
+          "lib": true,
+          "bin": true,
+          "share": true,
+          "tools": true
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Adds the components of the Azure C++ SDK that allow for interacting with Azure Identity systems, KeyVault, and Blob Storage. Intended to be used by TSCLicensing's integration tests.

Versions are:
- Core 1.16.4
- Identity 1.13.3
- KV Keys 4.4.1
- KV Secrets 4.2.1
- Storage Common 12.14.0


If you want to consume this in production code, you should know:
- Azure requires some form of authentication -- my current use case is perfectly allowable for auth via AzDO and/or a local usage of the Azure CLI. But if you want something more seamless in production you'd need to build in some kind of auth workflow in your consuming code.
- Since we're talking about integrating with a set of cloud services, considerations about app internet access and connectivity should apply. Don't build this into a workflow that has to work offline.

### Testing
- Verified that all 4 new targets build prebuilt packages successfully
- Verified that the identity and keyvault-secrets packages needed for my current work can be successfully built and linked in CommonCpp